### PR TITLE
fix(repeater-native): resolve workaround complexity with empty state support

### DIFF
--- a/packages/pluggableWidgets/repeater-native/src/Repeater.editorConfig.ts
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.editorConfig.ts
@@ -35,8 +35,8 @@ export function getPreview(values: RepeaterPreviewProps, isDarkMode: boolean): S
                 children: [
                     {
                         type: "DropZone",
-                        placeholder: "Content when Empty",
-                        property: values.contentEmpty
+                        placeholder: "No items placeholder: Place widgets here",
+                        property: values.emptyPlaceholder
                     }
                 ]
             }

--- a/packages/pluggableWidgets/repeater-native/src/Repeater.editorConfig.ts
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.editorConfig.ts
@@ -1,15 +1,45 @@
-import { StructurePreviewProps, topBar } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 
 import { RepeaterPreviewProps } from "../typings/RepeaterProps";
 
 export function getPreview(values: RepeaterPreviewProps, isDarkMode: boolean): StructurePreviewProps {
-    return topBar(
-        "Repeater",
-        {
-            type: "DropZone",
-            placeholder: "Content",
-            property: values.content
-        },
-        isDarkMode
-    );
+    return {
+        type: "Container",
+        borders: true,
+        children: [
+            {
+                type: "Container",
+                backgroundColor: isDarkMode ? "#454545" : "#F5F5F5",
+                children: [
+                    {
+                        type: "Container",
+                        padding: 4,
+                        children: [
+                            {
+                                type: "Text",
+                                fontColor: isDarkMode ? "#DEDEDE" : "#6B707B",
+                                content: "Repeater"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: "DropZone",
+                placeholder: "Content",
+                property: values.content
+            },
+            {
+                type: "Container",
+                borders: true,
+                children: [
+                    {
+                        type: "DropZone",
+                        placeholder: "Content when Empty",
+                        property: values.contentEmpty
+                    }
+                ]
+            }
+        ]
+    };
 }

--- a/packages/pluggableWidgets/repeater-native/src/Repeater.tsx
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.tsx
@@ -10,13 +10,13 @@ export function Repeater(props: RepeaterProps<RepeaterStyle>): ReactElement {
     if (props.datasource.status === ValueStatus.Loading || !props.datasource.items) {
         return <View />;
     }
-    const contentEmpty = props.datasource.items.length === 0 ? props.contentEmpty : null;
+    const emptyPlaceholder = props.datasource.items.length === 0 ? props.emptyPlaceholder : null;
     return (
         <View style={styles.container}>
             {props.datasource.items.map((item, index) => (
                 <Fragment key={`item_${index}`}>{props.content.get(item)}</Fragment>
             ))}
-            {contentEmpty}
+            {emptyPlaceholder}
         </View>
     );
 }

--- a/packages/pluggableWidgets/repeater-native/src/Repeater.tsx
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.tsx
@@ -7,19 +7,16 @@ import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
 
 export function Repeater(props: RepeaterProps<RepeaterStyle>): ReactElement {
     const styles = mergeNativeStyles(defaultRepeaterStyle, props.style);
-    if (
-        props.datasource.status === ValueStatus.Loading ||
-        !props.datasource.items ||
-        props.datasource.items.length === 0
-    ) {
+    if (props.datasource.status === ValueStatus.Loading || !props.datasource.items) {
         return <View />;
     }
-
+    const contentEmpty = props.datasource.items.length === 0 ? props.contentEmpty : null;
     return (
         <View style={styles.container}>
-            {props.datasource.items?.map((item, index) => (
+            {props.datasource.items.map((item, index) => (
                 <Fragment key={`item_${index}`}>{props.content.get(item)}</Fragment>
             ))}
+            {contentEmpty}
         </View>
     );
 }

--- a/packages/pluggableWidgets/repeater-native/src/Repeater.xml
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.xml
@@ -14,6 +14,10 @@
                 <property key="content" type="widgets" dataSource="datasource">
                     <caption>Content</caption>
                     <description/>
+                </property>                
+                <property key="contentEmpty" type="widgets" required="false">
+                    <caption>Content empty</caption>
+                    <description/>
                 </property>
             </propertyGroup>
             <propertyGroup caption="Common">

--- a/packages/pluggableWidgets/repeater-native/src/Repeater.xml
+++ b/packages/pluggableWidgets/repeater-native/src/Repeater.xml
@@ -15,8 +15,8 @@
                     <caption>Content</caption>
                     <description/>
                 </property>                
-                <property key="contentEmpty" type="widgets" required="false">
-                    <caption>Content empty</caption>
+                <property key="emptyPlaceholder" type="widgets" required="false">
+                    <caption>Empty placeholder</caption>
                     <description/>
                 </property>
             </propertyGroup>

--- a/packages/pluggableWidgets/repeater-native/typings/RepeaterProps.d.ts
+++ b/packages/pluggableWidgets/repeater-native/typings/RepeaterProps.d.ts
@@ -11,7 +11,7 @@ export interface RepeaterProps<Style> {
     style: Style[];
     datasource: ListValue;
     content: ListWidgetValue;
-    contentEmpty?: ReactNode;
+    emptyPlaceholder?: ReactNode;
 }
 
 export interface RepeaterPreviewProps {
@@ -27,5 +27,5 @@ export interface RepeaterPreviewProps {
     translate: (text: string) => string;
     datasource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
-    contentEmpty: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
+    emptyPlaceholder: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
 }

--- a/packages/pluggableWidgets/repeater-native/typings/RepeaterProps.d.ts
+++ b/packages/pluggableWidgets/repeater-native/typings/RepeaterProps.d.ts
@@ -11,6 +11,7 @@ export interface RepeaterProps<Style> {
     style: Style[];
     datasource: ListValue;
     content: ListWidgetValue;
+    contentEmpty?: ReactNode;
 }
 
 export interface RepeaterPreviewProps {
@@ -26,4 +27,5 @@ export interface RepeaterPreviewProps {
     translate: (text: string) => string;
     datasource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
+    contentEmpty: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
 }


### PR DESCRIPTION
## Fix: Add empty state configuration for Repeater widget

### Problem
When a Repeater displays no data, there is currently no way to show users a meaningful message or placeholder. This creates a poor UX where empty lists appear broken or unresponsive.

As a workaround, developers must create a surrounding context that:
- Manually counts results in advance
- Conditionally shows/hides UI based on the count
- Refreshes the entire context when data changes to zero

This workaround is error-prone and adds unnecessary model complexity.

### Solution
Add an `emptyListContent` configuration property to Repeater, allowing developers to define custom content shown when the list is empty.

This:
- Eliminates the need for manual count logic
- Simplifies the data model
- Provides a consistent UX pattern (aligns with Gallery widget behavior)
- Reduces maintenance overhead

### Context
Other data container widgets (ListView, Repeater in scroll context) cannot be safely nested in ScrollViews due to VirtualizedList conflicts. The Repeater is often the only viable option in these scenarios, making the empty state configuration essential for real-world applications.

### Reference
This implementation follows the existing pattern in the Gallery widget: https://github.com/mendix/native-widgets/blob/main/packages/pluggableWidgets/gallery-native/src/Gallery.xml#L59