### PR TITLE
Added cameratype (front/back) to properties of BarcodeScanner Native

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.tsx
@@ -21,6 +21,7 @@ export class BarcodeScanner extends Component<Props> {
                 <RNCamera
                     testID={this.props.name}
                     style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+                    type={this.props.cameraType  == 'back' ? RNCamera.Constants.Type.back : RNCamera.Constants.Type.front}
                     captureAudio={false}
                     onBarCodeRead={this.onBarCodeReadHandler}
                 >

--- a/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.xml
+++ b/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.xml
@@ -25,6 +25,16 @@
                     <description />
                 </property>
             </propertyGroup>
+            <propertyGroup caption="Camera"></propertyGroup>
+                <property key="cameraType" type="enumeration" required="true" defaultValue="back">
+                    <caption>Camera type</caption>
+                    <description>Select camera to use for the scanner.</description>
+                    <enumerationValues>
+                        <enumerationValue key="front">Front</enumerationValue>
+                        <enumerationValue key="back">back</enumerationValue>
+                    </enumerationValues>
+                </property>
+            </propertyGroup>
             <propertyGroup caption="Events">
                 <property key="onDetect" type="action" required="false">
                     <caption>On detect</caption>

--- a/packages/pluggableWidgets/barcode-scanner-native/typings/BarcodeScannerProps.d.ts
+++ b/packages/pluggableWidgets/barcode-scanner-native/typings/BarcodeScannerProps.d.ts
@@ -6,12 +6,15 @@
 import { CSSProperties } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
+export type CameraTypeEnum = "front" | "back";
+
 export interface BarcodeScannerProps<Style> {
     name: string;
     style: Style[];
     barcode: EditableValue<string>;
     showMask: boolean;
     showAnimatedLine: boolean;
+    cameraType: CameraTypeEnum;
     onDetect?: ActionValue;
 }
 
@@ -27,5 +30,6 @@ export interface BarcodeScannerPreviewProps {
     barcode: string;
     showMask: boolean;
     showAnimatedLine: boolean;
+    cameraType: CameraTypeEnum;
     onDetect: {} | null;
 }


### PR DESCRIPTION
On request of a customer we had to add an option to use the front camera for the BarcodeScanner (hanging tablet on a wall, where barcodes were presented to the tablet). This is a standard option on react-native-camera (see [doc](https://react-native-camera.github.io/react-native-camera/docs/rncamera#type)). 

Note that the front camera often is of less quality, so barcodes will be harder to scan. 

## Checklist

-   Contains unit tests ✅ ❌
-   Contains breaking changes ✅ ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ ❌
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

#### Feature specific

-   Comply with designs ✅ ❌
-   Comply with PM's requirements ✅ ❌

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

_..._

## Relevant changes

_Please add a high level explanation of what was changed and how the initial problem was solved_

## What should be covered while testing?

_..._

## Extra comments (optional)

_Please add extra comments or delete the section if not required_
