### PR TITLE
fix(bar-chart-native): crash with Mx10

### DIFF
--- a/packages/pluggableWidgets/bar-chart-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/bar-chart-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue when running with Mx10 crashes the app.
+
 ## [3.0.1] - 2023-5-17
 
 ### Fixed

--- a/packages/pluggableWidgets/bar-chart-native/src/package.xml
+++ b/packages/pluggableWidgets/bar-chart-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="BarChart" version="3.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="BarChart" version="3.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BarChart.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/bar-chart-native/src/utils/SeriesLoader.ts
+++ b/packages/pluggableWidgets/bar-chart-native/src/utils/SeriesLoader.ts
@@ -196,12 +196,12 @@ function extractDataPoints(series: BarSeriesType, dataSourceItems?: ObjectItem[]
     const dataPointsExtraction: DataPointsExtraction = { dataPoints: [] };
 
     for (const item of dataSourceItems) {
-        const x = (series.dataSet === "static" ? ensure(series.staticXAttribute) : ensure(series.dynamicXAttribute))(
-            item
-        );
-        const y = (series.dataSet === "static" ? ensure(series.staticYAttribute) : ensure(series.dynamicYAttribute))(
-            item
-        );
+        const x = (
+            series.dataSet === "static" ? ensure(series.staticXAttribute) : ensure(series.dynamicXAttribute)
+        ).get(item);
+        const y = (
+            series.dataSet === "static" ? ensure(series.staticYAttribute) : ensure(series.dynamicYAttribute)
+        ).get(item);
 
         if (!x.value || !y.value) {
             return null;


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes  ❌
-   Compatible with: MX 8️⃣, 9️⃣, 🔟
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

_Fix crash that appeared while using bar chart widget on native profiles with Mx10_

## Relevant changes

_using `editableValue.get(item)` instead of editableValue(item)_

## What should be covered while testing?

_ Bar chart widget should act the same expected way on Mx8, Mx9, and Mx10_
