### PR TITLE
fix(accordion-native): set value collapsed attribute

### DIFF
--- a/packages/pluggableWidgets/accordion-native/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-native/src/Accordion.tsx
@@ -42,14 +42,18 @@ export function Accordion(props: Props): ReactElement | null {
     const onPressGroupHeader = useCallback(
         (group: GroupsType, index: number): void => {
             const expanded = expandedGroups.includes(index);
+            let newExpandedGroup: number[] = []; // use new expanded group, as we need to state before we call execute action.
             if (expanded) {
+                newExpandedGroup = expandedGroups.filter(i => i !== index);
                 collapseGroup(index);
             } else {
+                newExpandedGroup = props.collapseBehavior === "singleExpanded" ? [index] : [...expandedGroups, index];
                 expandGroup(index);
             }
+            props.groups.forEach((g, i) => g.groupCollapsedAttribute?.setValue(!newExpandedGroup.includes(i)));
             executeAction(group.groupOnChange);
         },
-        [expandedGroups, expandGroup, collapseGroup]
+        [expandedGroups, props.groups, props.collapseBehavior, collapseGroup, expandGroup]
     );
 
     const checkPropertyValues = (group: GroupsType, i: number): void => {


### PR DESCRIPTION
As a user, I want to receive events on the change of the accordion state, collapsed or expanded.
We can set the "On change" action when editing the group. In this case, it triggers a nanoflow. Inside the nanoflow we like to know the current state of the accordion. We expect to get an up-to-date state through the "Collapsed" attribute.

The current issue is that the accordion no longer works when selecting the "Collapsed" attribute. 

Technically, this is caused by the widget reading the attribute's state to determine the accordion group's collapsed state. However, the widget never changes the attribute, preventing any update. 

See support ticket #202608

This PR update the active state, fixing this bug