### PR TITLE
fix(gallery-native): pull down only when selected

### DIFF
--- a/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
@@ -115,7 +115,7 @@ export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
             pagination={props.pagination}
             loadMoreButtonCaption={props.loadMoreButtonCaption}
             phoneColumns={props.phoneColumns}
-            pullDown={pullDown}
+            pullDown={props.pullDown ? pullDown : undefined}
             pullDownIsExecuting={props.pullDown?.isExecuting ?? false}
             scrollDirection={props.scrollDirection}
             style={styles}


### PR DESCRIPTION
About the native Gallery widget '' It has an event "Pull down" property, which helps add a refresh and reload function; however, when not using this function, the pull-to-refresh loading indicator is still visible to the users. 

This behaviour is unexpected, resulting in an inconsistent user experience. We expect that if "Pull down"  is set to "Do nothing", we do not expect it to be possible to pull down the content and show the load indicator. 

Technically, this causes useCallback function, which is always available, even if the users do not select the property pullDown. To fix this, please consider my suggestion via the GitHub pull request.
