### PR TITLE
Gallery Scroll Indicator

### DIFF
--- a/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
@@ -118,6 +118,7 @@ export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
             pullDown={props.pullDown && pullDown}
             pullDownIsExecuting={props.pullDown?.isExecuting ?? false}
             scrollDirection={props.scrollDirection}
+            showScrollIndicator={props.showScrollIndicator}
             style={styles}
             tabletColumns={props.tabletColumns}
         />

--- a/packages/pluggableWidgets/gallery-native/src/Gallery.xml
+++ b/packages/pluggableWidgets/gallery-native/src/Gallery.xml
@@ -24,6 +24,10 @@
                         <enumerationValue key="horizontal">Horizontal</enumerationValue>
                     </enumerationValues>
                 </property>
+                <property key="showScrollIndicator" type="boolean" defaultValue="true">
+                    <caption>Show scroll indicator</caption>
+                    <description /> 
+                </property>
             </propertyGroup>
             <propertyGroup caption="Columns">
                 <property key="tabletColumns" type="integer" defaultValue="1">

--- a/packages/pluggableWidgets/gallery-native/src/components/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-native/src/components/Gallery.tsx
@@ -23,6 +23,7 @@ export interface GalleryProps<T extends ObjectItem> {
     pullDown?: () => void;
     pullDownIsExecuting?: boolean;
     scrollDirection: ScrollDirectionEnum;
+    showScrollIndicator: boolean;
     style: GalleryStyle;
     tabletColumns: number;
 }
@@ -130,6 +131,8 @@ export const Gallery = <T extends ObjectItem>(props: GalleryProps<T>): ReactElem
                 renderItem={renderItem}
                 style={props.style.list}
                 testID={`${props.name}-list`}
+                showsHorizontalScrollIndicator={!isScrollDirectionVertical && props.showScrollIndicator}
+                showsVerticalScrollIndicator={isScrollDirectionVertical && props.showScrollIndicator}
             />
         </View>
     );

--- a/packages/pluggableWidgets/gallery-native/typings/GalleryProps.d.ts
+++ b/packages/pluggableWidgets/gallery-native/typings/GalleryProps.d.ts
@@ -25,6 +25,7 @@ export interface GalleryProps<Style> {
     datasource: ListValue;
     content?: ListWidgetValue;
     scrollDirection: ScrollDirectionEnum;
+    showScrollIndicator: boolean;
     tabletColumns: number;
     phoneColumns: number;
     pageSize: number;
@@ -49,6 +50,7 @@ export interface GalleryPreviewProps {
     datasource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     scrollDirection: ScrollDirectionEnum;
+    showScrollIndicator: boolean;
     tabletColumns: number | null;
     phoneColumns: number | null;
     pageSize: number | null;


### PR DESCRIPTION
Add the ability to hide the scroll indicator.

## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
-   Did you update version and changelog? ❌
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR adds the ability to hide the scroll indicators on the gallery widget.

## Relevant changes

Add a property to the widget to determine if the scroll indicators should show. The underlying list view already supports this functionality, so that property just gets passed to the widget.

## What should be covered while testing?

The default value is set to false so that it's backwards compatible.

