### PR TITLE
[MOO-1361] Add check and request EXACT_ALARM_PERMISSION to RequestGenericPermission

### DIFF
--- a/.github/actions/create-native-bundle/action.yml
+++ b/.github/actions/create-native-bundle/action.yml
@@ -41,7 +41,7 @@ runs:
       env:
         NODE_OPTIONS: --max_old_space_size=6144
     - name: "Upload bundle for ${{ inputs.platform }}"
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ${{ inputs.platform }}-bundle
         path: ${{ inputs.platform }}

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -146,7 +146,7 @@ jobs:
             mv -f resources/jsActions/nanoflow-actions-native/* Native-Mobile-Resources-main/javascriptsource/nanoflowcommons/actions/
           fi
       - name: "Build test project"
-        run: mxbuild -o automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
+        run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
       - name: "Get Mendix version"
         id: get-mendix-version
-        uses: notiz-dev/github-action-json-property@v0.2.0
+        uses: notiz-dev/github-action-json-property@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           path: configs/e2e/mendix-versions.json
           prop_path: latest
@@ -48,7 +48,7 @@ jobs:
       MENDIX_VERSION: ${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,11 +58,11 @@ jobs:
           docker manifest inspect ghcr.io/mendix/native-widgets/mxbuild:${{ env.MENDIX_VERSION }} || EXIT_CODE=$?
           echo "IMAGE_MISSING=$EXIT_CODE" >> $GITHUB_ENV
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: ${{ env.IMAGE_MISSING != 0 }}
       - name: "Build mxbuild image"
         if: ${{ env.IMAGE_MISSING != 0 }}
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           file: ./.github/scripts/mxbuild.Dockerfile
           context: ./.github/scripts
@@ -79,11 +79,11 @@ jobs:
       contents: read
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -96,7 +96,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: "Upload resources artifact"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: resources
           path: |
@@ -115,11 +115,11 @@ jobs:
       - name: "Download test project"
         run: curl -L -o project.zip https://github.com/mendix/Native-Mobile-Resources/archive/refs/heads/main.zip
       - name: "Extract test project"
-        uses: montudor/action-zip@v1.0.0
+        uses: montudor/action-zip@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           args: unzip -qq project.zip
       - name: "Download resources artifact"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: resources
           path: resources
@@ -148,7 +148,7 @@ jobs:
       - name: "Build test project"
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: mda
           path: automation.mda
@@ -158,9 +158,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
       - name: "Download deployment package"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: mda
       - name: "Create Android bundle"
@@ -174,9 +174,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: mda
       - name: "Create iOS bundle"
@@ -189,22 +189,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           path: native-widgets
       - name: "Download Android bundle and assets"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: android-bundle
           path: bundles/android
       - name: "Set up Node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -220,7 +220,7 @@ jobs:
         working-directory: native-template
         run: npm i
       - name: "Setup JDK 11"
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           java-version: 11
           distribution: temurin
@@ -229,7 +229,7 @@ jobs:
         working-directory: native-template/android
         run: ./gradlew assembleAppstoreDebug assembleAppstoreDebugAndroidTest
       - name: "Archive Android app"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: android-app
           path: native-template/android/app/build/outputs/apk/**/*.apk
@@ -238,22 +238,22 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           path: native-widgets
       - name: "Download iOS bundle and assets"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: ios-bundle
           path: bundles/ios
       - name: "Set up Node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -269,7 +269,7 @@ jobs:
         run: npm i
 
       - name: "Setup Pods cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           path: native-template/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -282,7 +282,7 @@ jobs:
         working-directory: native-template/ios
         run: xcodebuild -workspace NativeTemplate.xcworkspace -scheme nativeTemplate -configuration Debug -sdk iphonesimulator -derivedDataPath build ONLY_ACTIVE_ARCH=YES VALID_ARCHS="i386 x86_64"
       - name: "Archive iOS app"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: ios-app
           path: native-template/ios/build/Build/Products/**/*.app
@@ -290,9 +290,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
       - name: "Setup AVD cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         id: avd-cache
         with:
           path: |
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.27.0
+        uses: reactivecircus/android-emulator-runner@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           api-level: 30
           target: default
@@ -321,18 +321,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: mda
       - name: "Start runtime"
@@ -341,7 +341,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download Android app"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: android-app
           path: android-app
@@ -350,7 +350,7 @@ jobs:
           mkdir -p detox/apps
           find android-app -type f -iname "*.apk" -exec mv {} detox/apps/ \;
       - name: "Setup AVD cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         id: avd-cache
         with:
           path: |
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@v2.27.0
+        uses: reactivecircus/android-emulator-runner@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           api-level: 30
           target: default
@@ -381,14 +381,14 @@ jobs:
             adb shell pm install -r -g -t /data/local/tmp/detox/Test.apk 2>/dev/null
             yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:android
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: always()
         with:
           name: android-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: failure()
         with:
           name: android-screenshot-results
@@ -397,7 +397,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: always()
         with:
           name: android-artifacts
@@ -408,18 +408,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: mda
       # Used when new xCode version of simulator should be created
@@ -435,7 +435,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download iOS app"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         with:
           name: ios-app
           path: ios-app
@@ -458,14 +458,14 @@ jobs:
       - name: "Run tests"
         run: yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:ios
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: always()
         with:
           name: ios-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: failure()
         with:
           name: ios-screenshot-results
@@ -474,7 +474,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
         if: always()
         with:
           name: ios-artifacts

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
       - name: "Get Mendix version"
         id: get-mendix-version
-        uses: notiz-dev/github-action-json-property@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: notiz-dev/github-action-json-property@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           path: configs/e2e/mendix-versions.json
           prop_path: latest
@@ -48,7 +48,7 @@ jobs:
       MENDIX_VERSION: ${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: docker/login-action@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,11 +58,11 @@ jobs:
           docker manifest inspect ghcr.io/mendix/native-widgets/mxbuild:${{ env.MENDIX_VERSION }} || EXIT_CODE=$?
           echo "IMAGE_MISSING=$EXIT_CODE" >> $GITHUB_ENV
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: ${{ env.IMAGE_MISSING != 0 }}
       - name: "Build mxbuild image"
         if: ${{ env.IMAGE_MISSING != 0 }}
-        uses: docker/build-push-action@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: docker/build-push-action@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           file: ./.github/scripts/mxbuild.Dockerfile
           context: ./.github/scripts
@@ -79,11 +79,11 @@ jobs:
       contents: read
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -96,7 +96,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: "Upload resources artifact"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: resources
           path: |
@@ -115,11 +115,11 @@ jobs:
       - name: "Download test project"
         run: curl -L -o project.zip https://github.com/mendix/Native-Mobile-Resources/archive/refs/heads/main.zip
       - name: "Extract test project"
-        uses: montudor/action-zip@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: montudor/action-zip@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           args: unzip -qq project.zip
       - name: "Download resources artifact"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: resources
           path: resources
@@ -148,7 +148,7 @@ jobs:
       - name: "Build test project"
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: mda
           path: automation.mda
@@ -158,9 +158,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
       - name: "Download deployment package"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: mda
       - name: "Create Android bundle"
@@ -174,9 +174,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
       - name: "Download project MDA file"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: mda
       - name: "Create iOS bundle"
@@ -189,22 +189,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           path: native-widgets
       - name: "Download Android bundle and assets"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: android-bundle
           path: bundles/android
       - name: "Set up Node"
-        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -220,7 +220,7 @@ jobs:
         working-directory: native-template
         run: npm i
       - name: "Setup JDK 11"
-        uses: actions/setup-java@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-java@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           java-version: 11
           distribution: temurin
@@ -229,7 +229,7 @@ jobs:
         working-directory: native-template/android
         run: ./gradlew assembleAppstoreDebug assembleAppstoreDebugAndroidTest
       - name: "Archive Android app"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: android-app
           path: native-template/android/app/build/outputs/apk/**/*.apk
@@ -238,22 +238,22 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           path: native-widgets
       - name: "Download iOS bundle and assets"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: ios-bundle
           path: bundles/ios
       - name: "Set up Node"
-        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -269,7 +269,7 @@ jobs:
         run: npm i
 
       - name: "Setup Pods cache"
-        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           path: native-template/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -282,7 +282,7 @@ jobs:
         working-directory: native-template/ios
         run: xcodebuild -workspace NativeTemplate.xcworkspace -scheme nativeTemplate -configuration Debug -sdk iphonesimulator -derivedDataPath build ONLY_ACTIVE_ARCH=YES VALID_ARCHS="i386 x86_64"
       - name: "Archive iOS app"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: ios-app
           path: native-template/ios/build/Build/Products/**/*.app
@@ -290,9 +290,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
       - name: "Setup AVD cache"
-        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         id: avd-cache
         with:
           path: |
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: reactivecircus/android-emulator-runner@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           api-level: 30
           target: default
@@ -321,18 +321,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: mda
       - name: "Start runtime"
@@ -341,7 +341,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download Android app"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: android-app
           path: android-app
@@ -350,7 +350,7 @@ jobs:
           mkdir -p detox/apps
           find android-app -type f -iname "*.apk" -exec mv {} detox/apps/ \;
       - name: "Setup AVD cache"
-        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         id: avd-cache
         with:
           path: |
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: reactivecircus/android-emulator-runner@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           api-level: 30
           target: default
@@ -381,14 +381,14 @@ jobs:
             adb shell pm install -r -g -t /data/local/tmp/detox/Test.apk 2>/dev/null
             yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:android
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: always()
         with:
           name: android-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: failure()
         with:
           name: android-screenshot-results
@@ -397,7 +397,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: always()
         with:
           name: android-artifacts
@@ -408,18 +408,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: mda
       # Used when new xCode version of simulator should be created
@@ -435,7 +435,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download iOS app"
-        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         with:
           name: ios-app
           path: ios-app
@@ -458,14 +458,14 @@ jobs:
       - name: "Run tests"
         run: yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:ios
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: always()
         with:
           name: ios-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: failure()
         with:
           name: ios-screenshot-results
@@ -474,7 +474,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
+        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
         if: always()
         with:
           name: ios-artifacts

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -146,7 +146,6 @@ jobs:
             mv -f resources/jsActions/nanoflow-actions-native/* Native-Mobile-Resources-main/javascriptsource/nanoflowcommons/actions/
           fi
       - name: "Build test project"
-        uses: actions/checkout@v1.0.0
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
       - name: "Get Mendix version"
         id: get-mendix-version
-        uses: notiz-dev/github-action-json-property@v0.2.0
+        uses: notiz-dev/github-action-json-property@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           path: configs/e2e/mendix-versions.json
           prop_path: latest
@@ -48,7 +48,7 @@ jobs:
       MENDIX_VERSION: ${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,11 +58,11 @@ jobs:
           docker manifest inspect ghcr.io/mendix/native-widgets/mxbuild:${{ env.MENDIX_VERSION }} || EXIT_CODE=$?
           echo "IMAGE_MISSING=$EXIT_CODE" >> $GITHUB_ENV
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: ${{ env.IMAGE_MISSING != 0 }}
       - name: "Build mxbuild image"
         if: ${{ env.IMAGE_MISSING != 0 }}
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           file: ./.github/scripts/mxbuild.Dockerfile
           context: ./.github/scripts
@@ -79,11 +79,11 @@ jobs:
       contents: read
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -96,7 +96,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: "Upload resources artifact"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: resources
           path: |
@@ -115,11 +115,11 @@ jobs:
       - name: "Download test project"
         run: curl -L -o project.zip https://github.com/mendix/Native-Mobile-Resources/archive/refs/heads/main.zip
       - name: "Extract test project"
-        uses: montudor/action-zip@v1.0.0
+        uses: montudor/action-zip@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           args: unzip -qq project.zip
       - name: "Download resources artifact"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: resources
           path: resources
@@ -148,7 +148,7 @@ jobs:
       - name: "Build test project"
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: mda
           path: automation.mda
@@ -158,9 +158,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
       - name: "Download deployment package"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: mda
       - name: "Create Android bundle"
@@ -174,9 +174,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: mda
       - name: "Create iOS bundle"
@@ -189,22 +189,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           path: native-widgets
       - name: "Download Android bundle and assets"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: android-bundle
           path: bundles/android
       - name: "Set up Node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -220,7 +220,7 @@ jobs:
         working-directory: native-template
         run: npm i
       - name: "Setup JDK 11"
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           java-version: 11
           distribution: temurin
@@ -229,7 +229,7 @@ jobs:
         working-directory: native-template/android
         run: ./gradlew assembleAppstoreDebug assembleAppstoreDebugAndroidTest
       - name: "Archive Android app"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: android-app
           path: native-template/android/app/build/outputs/apk/**/*.apk
@@ -238,22 +238,22 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           path: native-widgets
       - name: "Download iOS bundle and assets"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: ios-bundle
           path: bundles/ios
       - name: "Set up Node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -269,7 +269,7 @@ jobs:
         run: npm i
 
       - name: "Setup Pods cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           path: native-template/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -282,7 +282,7 @@ jobs:
         working-directory: native-template/ios
         run: xcodebuild -workspace NativeTemplate.xcworkspace -scheme nativeTemplate -configuration Debug -sdk iphonesimulator -derivedDataPath build ONLY_ACTIVE_ARCH=YES VALID_ARCHS="i386 x86_64"
       - name: "Archive iOS app"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: ios-app
           path: native-template/ios/build/Build/Products/**/*.app
@@ -290,9 +290,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
       - name: "Setup AVD cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
         id: avd-cache
         with:
           path: |
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.27.0
+        uses: reactivecircus/android-emulator-runner@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           api-level: 30
           target: default
@@ -321,18 +321,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: mda
       - name: "Start runtime"
@@ -341,7 +341,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download Android app"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: android-app
           path: android-app
@@ -350,7 +350,7 @@ jobs:
           mkdir -p detox/apps
           find android-app -type f -iname "*.apk" -exec mv {} detox/apps/ \;
       - name: "Setup AVD cache"
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@677f6d67b74a9830b3224211359ca18bdd4e961d
         id: avd-cache
         with:
           path: |
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@v2.27.0
+        uses: reactivecircus/android-emulator-runner@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           api-level: 30
           target: default
@@ -381,14 +381,14 @@ jobs:
             adb shell pm install -r -g -t /data/local/tmp/detox/Test.apk 2>/dev/null
             yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:android
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: always()
         with:
           name: android-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: failure()
         with:
           name: android-screenshot-results
@@ -397,7 +397,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: always()
         with:
           name: android-artifacts
@@ -408,18 +408,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: mda
       # Used when new xCode version of simulator should be created
@@ -435,7 +435,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download iOS app"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         with:
           name: ios-app
           path: ios-app
@@ -458,14 +458,14 @@ jobs:
       - name: "Run tests"
         run: yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:ios
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: always()
         with:
           name: ios-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: failure()
         with:
           name: ios-screenshot-results
@@ -474,7 +474,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@677f6d67b74a9830b3224211359ca18bdd4e961d
         if: always()
         with:
           name: ios-artifacts

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
       - name: "Get Mendix version"
         id: get-mendix-version
-        uses: notiz-dev/github-action-json-property@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: notiz-dev/github-action-json-property@v0.2.0
         with:
           path: configs/e2e/mendix-versions.json
           prop_path: latest
@@ -48,7 +48,7 @@ jobs:
       MENDIX_VERSION: ${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,11 +58,11 @@ jobs:
           docker manifest inspect ghcr.io/mendix/native-widgets/mxbuild:${{ env.MENDIX_VERSION }} || EXIT_CODE=$?
           echo "IMAGE_MISSING=$EXIT_CODE" >> $GITHUB_ENV
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         if: ${{ env.IMAGE_MISSING != 0 }}
       - name: "Build mxbuild image"
         if: ${{ env.IMAGE_MISSING != 0 }}
-        uses: docker/build-push-action@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: docker/build-push-action@v4.0.0
         with:
           file: ./.github/scripts/mxbuild.Dockerfile
           context: ./.github/scripts
@@ -79,11 +79,11 @@ jobs:
       contents: read
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-node@v3.6.0
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -96,7 +96,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: "Upload resources artifact"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: resources
           path: |
@@ -115,11 +115,11 @@ jobs:
       - name: "Download test project"
         run: curl -L -o project.zip https://github.com/mendix/Native-Mobile-Resources/archive/refs/heads/main.zip
       - name: "Extract test project"
-        uses: montudor/action-zip@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: montudor/action-zip@v1.0.0
         with:
           args: unzip -qq project.zip
       - name: "Download resources artifact"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: resources
           path: resources
@@ -148,7 +148,7 @@ jobs:
       - name: "Build test project"
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: mda
           path: automation.mda
@@ -158,9 +158,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
       - name: "Download deployment package"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: mda
       - name: "Create Android bundle"
@@ -174,9 +174,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
       - name: "Download project MDA file"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: mda
       - name: "Create iOS bundle"
@@ -189,22 +189,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           path: native-widgets
       - name: "Download Android bundle and assets"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: android-bundle
           path: bundles/android
       - name: "Set up Node"
-        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-node@v3.6.0
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -220,7 +220,7 @@ jobs:
         working-directory: native-template
         run: npm i
       - name: "Setup JDK 11"
-        uses: actions/setup-java@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-java@v3.10.0
         with:
           java-version: 11
           distribution: temurin
@@ -229,7 +229,7 @@ jobs:
         working-directory: native-template/android
         run: ./gradlew assembleAppstoreDebug assembleAppstoreDebugAndroidTest
       - name: "Archive Android app"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: android-app
           path: native-template/android/app/build/outputs/apk/**/*.apk
@@ -238,22 +238,22 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           path: native-widgets
       - name: "Download iOS bundle and assets"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ios-bundle
           path: bundles/ios
       - name: "Set up Node"
-        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-node@v3.6.0
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -269,7 +269,7 @@ jobs:
         run: npm i
 
       - name: "Setup Pods cache"
-        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/cache@v3.3.1
         with:
           path: native-template/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -282,7 +282,7 @@ jobs:
         working-directory: native-template/ios
         run: xcodebuild -workspace NativeTemplate.xcworkspace -scheme nativeTemplate -configuration Debug -sdk iphonesimulator -derivedDataPath build ONLY_ACTIVE_ARCH=YES VALID_ARCHS="i386 x86_64"
       - name: "Archive iOS app"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ios-app
           path: native-template/ios/build/Build/Products/**/*.app
@@ -290,9 +290,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
       - name: "Setup AVD cache"
-        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/cache@v3.3.1
         id: avd-cache
         with:
           path: |
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: reactivecircus/android-emulator-runner@v2.27.0
         with:
           api-level: 30
           target: default
@@ -321,18 +321,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-node@v3.6.0
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: mda
       - name: "Start runtime"
@@ -341,7 +341,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download Android app"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: android-app
           path: android-app
@@ -350,7 +350,7 @@ jobs:
           mkdir -p detox/apps
           find android-app -type f -iname "*.apk" -exec mv {} detox/apps/ \;
       - name: "Setup AVD cache"
-        uses: actions/cache@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/cache@v3.3.1
         id: avd-cache
         with:
           path: |
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: reactivecircus/android-emulator-runner@v2.27.0
         with:
           api-level: 30
           target: default
@@ -381,14 +381,14 @@ jobs:
             adb shell pm install -r -g -t /data/local/tmp/detox/Test.apk 2>/dev/null
             yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:android
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
           name: android-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: failure()
         with:
           name: android-screenshot-results
@@ -397,7 +397,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
           name: android-artifacts
@@ -408,18 +408,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/checkout@v3.4.0
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/setup-node@v3.6.0
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: mda
       # Used when new xCode version of simulator should be created
@@ -435,7 +435,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download iOS app"
-        uses: actions/download-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ios-app
           path: ios-app
@@ -458,14 +458,14 @@ jobs:
       - name: "Run tests"
         run: yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:ios
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
           name: ios-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: failure()
         with:
           name: ios-screenshot-results
@@ -474,7 +474,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@4bc75f6e46cd5dc99bd0598611e17fc5edae4c68
+        uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
           name: ios-artifacts

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.1
+        uses: actions/checkout@v3.4.0
       - name: "Get Mendix version"
         id: get-mendix-version
         uses: notiz-dev/github-action-json-property@v0.2.0

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - name: "Get Mendix version"
         id: get-mendix-version
-        uses: notiz-dev/github-action-json-property@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: notiz-dev/github-action-json-property@7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3 # v0.2.0
         with:
           path: configs/e2e/mendix-versions.json
           prop_path: latest
@@ -48,7 +48,7 @@ jobs:
       MENDIX_VERSION: ${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,11 +58,11 @@ jobs:
           docker manifest inspect ghcr.io/mendix/native-widgets/mxbuild:${{ env.MENDIX_VERSION }} || EXIT_CODE=$?
           echo "IMAGE_MISSING=$EXIT_CODE" >> $GITHUB_ENV
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         if: ${{ env.IMAGE_MISSING != 0 }}
       - name: "Build mxbuild image"
         if: ${{ env.IMAGE_MISSING != 0 }}
-        uses: docker/build-push-action@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           file: ./.github/scripts/mxbuild.Dockerfile
           context: ./.github/scripts
@@ -79,11 +79,11 @@ jobs:
       contents: read
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -96,7 +96,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: "Upload resources artifact"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: resources
           path: |
@@ -115,11 +115,11 @@ jobs:
       - name: "Download test project"
         run: curl -L -o project.zip https://github.com/mendix/Native-Mobile-Resources/archive/refs/heads/main.zip
       - name: "Extract test project"
-        uses: montudor/action-zip@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
         with:
           args: unzip -qq project.zip
       - name: "Download resources artifact"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: resources
           path: resources
@@ -148,7 +148,7 @@ jobs:
       - name: "Build test project"
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: mda
           path: automation.mda
@@ -158,9 +158,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - name: "Download deployment package"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: mda
       - name: "Create Android bundle"
@@ -174,9 +174,9 @@ jobs:
     container: ghcr.io/mendix/native-widgets/mxbuild:${{ needs.mendix-version.outputs.mendix-version }}
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - name: "Download project MDA file"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: mda
       - name: "Create iOS bundle"
@@ -189,22 +189,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           path: native-widgets
       - name: "Download Android bundle and assets"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: android-bundle
           path: bundles/android
       - name: "Set up Node"
-        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -220,7 +220,7 @@ jobs:
         working-directory: native-template
         run: npm i
       - name: "Setup JDK 11"
-        uses: actions/setup-java@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: 11
           distribution: temurin
@@ -229,7 +229,7 @@ jobs:
         working-directory: native-template/android
         run: ./gradlew assembleAppstoreDebug assembleAppstoreDebugAndroidTest
       - name: "Archive Android app"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: android-app
           path: native-template/android/app/build/outputs/apk/**/*.apk
@@ -238,22 +238,22 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out Native Template for Native Components Test Project"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           repository: mendix/native-template
           ref: master
           path: native-template
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           path: native-widgets
       - name: "Download iOS bundle and assets"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ios-bundle
           path: bundles/ios
       - name: "Set up Node"
-        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version-file: native-template/.nvmrc
           cache: npm
@@ -269,7 +269,7 @@ jobs:
         run: npm i
 
       - name: "Setup Pods cache"
-        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2
         with:
           path: native-template/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -282,7 +282,7 @@ jobs:
         working-directory: native-template/ios
         run: xcodebuild -workspace NativeTemplate.xcworkspace -scheme nativeTemplate -configuration Debug -sdk iphonesimulator -derivedDataPath build ONLY_ACTIVE_ARCH=YES VALID_ARCHS="i386 x86_64"
       - name: "Archive iOS app"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ios-app
           path: native-template/ios/build/Build/Products/**/*.app
@@ -290,9 +290,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - name: "Setup AVD cache"
-        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2
         id: avd-cache
         with:
           path: |
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: reactivecircus/android-emulator-runner@61a61f94a9ac9060497efab4ebd3a108af49e2ec # v2.30.1
         with:
           api-level: 30
           target: default
@@ -321,18 +321,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: mda
       - name: "Start runtime"
@@ -341,7 +341,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download Android app"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: android-app
           path: android-app
@@ -350,7 +350,7 @@ jobs:
           mkdir -p detox/apps
           find android-app -type f -iname "*.apk" -exec mv {} detox/apps/ \;
       - name: "Setup AVD cache"
-        uses: actions/cache@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2
         id: avd-cache
         with:
           path: |
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: reactivecircus/android-emulator-runner@61a61f94a9ac9060497efab4ebd3a108af49e2ec # v2.30.1
         with:
           api-level: 30
           target: default
@@ -381,14 +381,14 @@ jobs:
             adb shell pm install -r -g -t /data/local/tmp/detox/Test.apk 2>/dev/null
             yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:android
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:
           name: android-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: failure()
         with:
           name: android-screenshot-results
@@ -397,7 +397,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:
           name: android-artifacts
@@ -408,18 +408,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Check out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           fetch-depth: 0
       - name: "Set up node"
-        uses: actions/setup-node@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version-file: .nvmrc
           cache: yarn
       - name: "Install dependencies"
         run: yarn install --immutable
       - name: "Download project MDA file"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: mda
       # Used when new xCode version of simulator should be created
@@ -435,7 +435,7 @@ jobs:
           mda-file: automation.mda
           mendix-version: ${{ needs.mendix-version.outputs.mendix-version }}
       - name: "Download iOS app"
-        uses: actions/download-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ios-app
           path: ios-app
@@ -458,14 +458,14 @@ jobs:
       - name: "Run tests"
         run: yarn workspaces foreach ${{ needs.scope.outputs.scope }} run test:e2e:ios
       - name: "Archive runtime logs"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:
           name: ios-runtime-logs
           path: log/*.log
           if-no-files-found: ignore
       - name: "Archive test screenshot diff results"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: failure()
         with:
           name: ios-screenshot-results
@@ -474,7 +474,7 @@ jobs:
             ${{ github.workspace }}/packages/**/e2e/images/actual/**/*.png
           if-no-files-found: ignore
       - name: "Archive artifacts"
-        uses: actions/upload-artifact@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:
           name: ios-artifacts

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@87e972298f2bdb78b25f1589966781e2b5c290ac # v2.27.0
+        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2.30.1
         with:
           api-level: 30
           target: default
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@87e972298f2bdb78b25f1589966781e2b5c290ac # v2.27.0
+        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2.30.1
         with:
           api-level: 30
           target: default

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -146,7 +146,7 @@ jobs:
             mv -f resources/jsActions/nanoflow-actions-native/* Native-Mobile-Resources-main/javascriptsource/nanoflowcommons/actions/
           fi
       - name: "Build test project"
-        run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
+        run: mxbuild -o automation.mda --loose-version-check Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -146,6 +146,7 @@ jobs:
             mv -f resources/jsActions/nanoflow-actions-native/* Native-Mobile-Resources-main/javascriptsource/nanoflowcommons/actions/
           fi
       - name: "Build test project"
+        uses: actions/checkout@v1.0.0
         run: mxbuild -o --loose-version-check automation.mda Native-Mobile-Resources-main/NativeComponentsTestProject.mpr
       - name: "Upload MDA"
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v3.4.1
       - name: "Get Mendix version"
         id: get-mendix-version
         uses: notiz-dev/github-action-json-property@v0.2.0

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -219,10 +219,10 @@ jobs:
       - name: "Install dependencies"
         working-directory: native-template
         run: npm i
-      - name: "Setup JDK 11"
+      - name: "Setup JDK 17"
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
           cache: gradle
       - name: "Build Android app"

--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -302,7 +302,7 @@ jobs:
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Create AVD and generate snapshot for caching"
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@61a61f94a9ac9060497efab4ebd3a108af49e2ec # v2.30.1
+        uses: reactivecircus/android-emulator-runner@87e972298f2bdb78b25f1589966781e2b5c290ac # v2.27.0
         with:
           api-level: 30
           target: default
@@ -359,7 +359,7 @@ jobs:
             /Users/runner/Library/Android/sdk/system-images/**/*
           key: pixel_30_x86_64_default_3core_and_system_images
       - name: "Run tests"
-        uses: reactivecircus/android-emulator-runner@61a61f94a9ac9060497efab4ebd3a108af49e2ec # v2.30.1
+        uses: reactivecircus/android-emulator-runner@87e972298f2bdb78b25f1589966781e2b5c290ac # v2.27.0
         with:
           api-level: 30
           target: default

--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           submodules: false
       - name: "Ensure SHA pinned actions"
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@5c6142ee95066fc1ae17c5e2713712f5876d0689 # v1.1.2
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@0b552a197e44b819629237e065d781f5ca691460 # v1.1.1

--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checking-out code"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v4
         with:
           submodules: false
       - name: "Ensure SHA pinned actions"

--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checking-out code"
-        uses: actions/checkout@b44b924715cf27938426f1e1b8ed5fe31492eb67 # v4
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           submodules: false
       - name: "Ensure SHA pinned actions"

--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           submodules: false
       - name: "Ensure SHA pinned actions"
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@0b552a197e44b819629237e065d781f5ca691460 # v1.1.1
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@5c6142ee95066fc1ae17c5e2713712f5876d0689 # v1.1.2

--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+-   Added CheckGenericPermission and updated RequestGenericPermission to support SCHEDULE_EXACT_ALARM_ANDROID permission for Android (relevant for Android 14).
+
+### Changed
+
 -   fixed an Android issue in Download file action.
 
 ## [6.0.0] Native Mobile Resources - 2024-01-24

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -39,6 +39,7 @@
     "react-native-localize": "1.4.2",
     "react-native-permissions": "3.3.1",
     "react-native-push-notification": "8.1.1",
+    "react-native-schedule-exact-alarm-permission": "^0.1.3",
     "react-native-sound": "0.11.0",
     "react-native-touch-id": "4.4.1",
     "url-parse": "^1.4.7"

--- a/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
@@ -5,16 +5,12 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
-import { Alert, Platform, NativeModules } from "react-native";
+import { Platform, NativeModules } from "react-native";
 import {
     check,
-    request,
-    RESULTS,
-    openSettings,
     Permission,
     PERMISSIONS as RNPermissions
 } from "react-native-permissions";
-import { getPermission } from "react-native-schedule-exact-alarm-permission";
 import { ANDROIDPermissionName, IOSPermissionName } from "../../typings/RequestGenericPermission";
 
 // BEGIN EXTRA CODE
@@ -26,22 +22,6 @@ const PERMISSIONS = {
     },
     IOS: RNPermissions.IOS
 };
-
-function handleBlockedPermission(permission: string): void {
-    const permissionName = permission.replace(/_IOS|_ANDROID/, "");
-
-    if (permissionName === "SCHEDULE_EXACT_ALARM") {
-        Alert.alert("", "Please allow setting alarms and reminders", [
-            { text: "Go to alarm settings", onPress: () => getPermission(), isPreferred: true },
-            { text: "Cancel", style: "cancel" }
-        ]);
-    } else {
-        Alert.alert("", `Please allow ${permissionName} access`, [
-            { text: "Go to settings", onPress: () => openSettings(), isPreferred: true },
-            { text: "Cancel", style: "cancel" }
-        ]);
-    }
-}
 
 function mapPermissionName(permissionName: string): Permission | "android.permission.SCHEDULE_EXACT_ALARM" | undefined {
     if (Platform.OS === "ios") {
@@ -81,7 +61,7 @@ async function checkScheduleAlarm(): Promise<"granted" | "blocked"> {
  * @param {"NanoflowCommons.Enum_Permissions.APP_TRACKING_TRANSPARENCY_IOS"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_PERIPHERAL_IOS"|"NanoflowCommons.Enum_Permissions.CAMERA_IOS"|"NanoflowCommons.Enum_Permissions.CALENDARS_IOS"|"NanoflowCommons.Enum_Permissions.CONTACTS_IOS"|"NanoflowCommons.Enum_Permissions.FACE_ID_IOS"|"NanoflowCommons.Enum_Permissions.LOCATION_ALWAYS_IOS"|"NanoflowCommons.Enum_Permissions.LOCATION_WHEN_IN_USE_IOS"|"NanoflowCommons.Enum_Permissions.MEDIA_LIBRARY_IOS"|"NanoflowCommons.Enum_Permissions.MICROPHONE_IOS"|"NanoflowCommons.Enum_Permissions.MOTION_IOS"|"NanoflowCommons.Enum_Permissions.PHOTO_LIBRARY_IOS"|"NanoflowCommons.Enum_Permissions.PHOTO_LIBRARY_ADD_ONLY_IOS"|"NanoflowCommons.Enum_Permissions.REMINDERS_IOS"|"NanoflowCommons.Enum_Permissions.SIRI_IOS"|"NanoflowCommons.Enum_Permissions.SPEECH_RECOGNITION_IOS"|"NanoflowCommons.Enum_Permissions.STOREKIT_IOS"|"NanoflowCommons.Enum_Permissions.ACCEPT_HANDOVER_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_BACKGROUND_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_COARSE_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_FINE_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_MEDIA_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACTIVITY_RECOGNITION_ANDROID"|"NanoflowCommons.Enum_Permissions.ADD_VOICEMAIL_ANDROID"|"NanoflowCommons.Enum_Permissions.ANSWER_PHONE_CALLS_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_ADVERTISE_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_CONNECT_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_SCAN_ANDROID"|"NanoflowCommons.Enum_Permissions.BODY_SENSORS_ANDROID"|"NanoflowCommons.Enum_Permissions.CALL_PHONE_ANDROID"|"NanoflowCommons.Enum_Permissions.CAMERA_ANDROID"|"NanoflowCommons.Enum_Permissions.GET_ACCOUNTS_ANDROID"|"NanoflowCommons.Enum_Permissions.PROCESS_OUTGOING_CALLS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CALENDAR_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CALL_LOG_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CONTACTS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_EXTERNAL_STORAGE_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_PHONE_NUMBERS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_PHONE_STATE_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_MMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_WAP_PUSH_ANDROID"|"NanoflowCommons.Enum_Permissions.RECORD_AUDIO_ANDROID"|"NanoflowCommons.Enum_Permissions.SEND_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.USE_SIP_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CALENDAR_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CALL_LOG_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CONTACTS_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_EXTERNAL_STORAGE_ANDROID"|"NanoflowCommons.Enum_Permissions.SCHEDULE_EXACT_ALARM_ANDROID"} permission - This field is required.
  * @returns {Promise.<"NanoflowCommons.Enum_PermissionStatus.unavailable"|"NanoflowCommons.Enum_PermissionStatus.denied"|"NanoflowCommons.Enum_PermissionStatus.limited"|"NanoflowCommons.Enum_PermissionStatus.granted"|"NanoflowCommons.Enum_PermissionStatus.blocked">}
  */
-export async function RequestGenericPermission(
+export async function CheckGenericPermission(
     permission?: string
 ): Promise<"unavailable" | "blocked" | "denied" | "granted" | "limited"> {
     // BEGIN USER CODE
@@ -95,21 +75,9 @@ export async function RequestGenericPermission(
         return Promise.resolve("unavailable");
     }
 
-    const permissionStatus =
-        mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
+
+    return mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
             ? await checkScheduleAlarm()
             : await check(mappedPermissionName as Permission);
-
-    switch (permissionStatus) {
-        case RESULTS.GRANTED:
-        case RESULTS.UNAVAILABLE:
-        case RESULTS.LIMITED:
-            return permissionStatus;
-        case RESULTS.BLOCKED:
-            handleBlockedPermission(permission);
-            return RESULTS.BLOCKED;
-        case RESULTS.DENIED:
-            return request(mappedPermissionName as Permission);
-    }
     // END USER CODE
 }

--- a/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
@@ -6,11 +6,7 @@
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
 import { Platform, NativeModules } from "react-native";
-import {
-    check,
-    Permission,
-    PERMISSIONS as RNPermissions
-} from "react-native-permissions";
+import { check, Permission, PERMISSIONS as RNPermissions } from "react-native-permissions";
 import { ANDROIDPermissionName, IOSPermissionName } from "../../typings/RequestGenericPermission";
 
 // BEGIN EXTRA CODE
@@ -75,9 +71,8 @@ export async function CheckGenericPermission(
         return Promise.resolve("unavailable");
     }
 
-
     return mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
-            ? await checkScheduleAlarm()
-            : await check(mappedPermissionName as Permission);
+        ? checkScheduleAlarm()
+        : check(mappedPermissionName as Permission);
     // END USER CODE
 }

--- a/packages/jsActions/mobile-resources-native/typings/RequestGenericPermission.d.ts
+++ b/packages/jsActions/mobile-resources-native/typings/RequestGenericPermission.d.ts
@@ -50,4 +50,5 @@ export type ANDROIDPermissionName =
     | "WRITE_CALENDAR"
     | "WRITE_CALL_LOG"
     | "WRITE_CONTACTS"
-    | "WRITE_EXTERNAL_STORAGE";
+    | "WRITE_EXTERNAL_STORAGE"
+    | "SCHEDULE_EXACT_ALARM";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12683,6 +12683,7 @@ __metadata:
     react-native-localize: 1.4.2
     react-native-permissions: 3.3.1
     react-native-push-notification: 8.1.1
+    react-native-schedule-exact-alarm-permission: ^0.1.3
     react-native-sound: 0.11.0
     react-native-touch-id: 4.4.1
     rimraf: ^2.7.1
@@ -14948,6 +14949,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: b2c3e599729f80a6339889daf872f64206ca7960c10b5f4a3ac12a047690b27ec4e19abf73c9069411b6987fdad8fea15c79acbb61332342b9e959f69f84c217
+  languageName: node
+  linkType: hard
+
+"react-native-schedule-exact-alarm-permission@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "react-native-schedule-exact-alarm-permission@npm:0.1.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: cadb1c6d17588beab4532cde73eeb943f4bf1ebb08e9e52d3cd291d3674a6d9b84ec8a590b6ff24e4fd8b671e342a12cf81b35ef4d46e927cf321442340480ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've added check and request EXACT_ALARM_PERMISSION to RequestGenericPermission. Current version of "react-native-permission" doesnt support SCHEDULE_EXACT_ALARM for Android, so I've added it using another library and combined with already existing functions. This permission is enabled by default on Android API SDK <= 33, but targeting 34 (Android 14) it's became disabled. To ensure that local notifications will work on Android 14, we have to add manual permission request.

