### PR TITLE
[MOO-1361] Add check and request EXACT_ALARM_PERMISSION to RequestGenericPermission (9.24)

### DIFF
--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   Added CheckGenericPermission and updated RequestGenericPermission to support SCHEDULE_EXACT_ALARM_ANDROID permission for Android (relevant for Android 14).
+
 ## [4.0.9] Native Mobile Resources - 2024-4-4
 
 

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -39,6 +39,7 @@
     "react-native-localize": "1.4.2",
     "react-native-permissions": "3.3.1",
     "react-native-push-notification": "8.1.1",
+    "react-native-schedule-exact-alarm-permission": "^0.1.3",
     "react-native-sound": "0.11.0",
     "react-native-touch-id": "4.4.1",
     "url-parse": "^1.4.7"

--- a/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
@@ -5,16 +5,12 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
-import { Alert, Platform, NativeModules } from "react-native";
+import { Platform, NativeModules } from "react-native";
 import {
     check,
-    request,
-    RESULTS,
-    openSettings,
     Permission,
     PERMISSIONS as RNPermissions
 } from "react-native-permissions";
-import { getPermission } from "react-native-schedule-exact-alarm-permission";
 import { ANDROIDPermissionName, IOSPermissionName } from "../../typings/RequestGenericPermission";
 
 // BEGIN EXTRA CODE
@@ -26,22 +22,6 @@ const PERMISSIONS = {
     },
     IOS: RNPermissions.IOS
 };
-
-function handleBlockedPermission(permission: string): void {
-    const permissionName = permission.replace(/_IOS|_ANDROID/, "");
-
-    if (permissionName === "SCHEDULE_EXACT_ALARM") {
-        Alert.alert("", "Please allow setting alarms and reminders", [
-            { text: "Go to alarm settings", onPress: () => getPermission(), isPreferred: true },
-            { text: "Cancel", style: "cancel" }
-        ]);
-    } else {
-        Alert.alert("", `Please allow ${permissionName} access`, [
-            { text: "Go to settings", onPress: () => openSettings(), isPreferred: true },
-            { text: "Cancel", style: "cancel" }
-        ]);
-    }
-}
 
 function mapPermissionName(permissionName: string): Permission | "android.permission.SCHEDULE_EXACT_ALARM" | undefined {
     if (Platform.OS === "ios") {
@@ -81,7 +61,7 @@ async function checkScheduleAlarm(): Promise<"granted" | "blocked"> {
  * @param {"NanoflowCommons.Enum_Permissions.APP_TRACKING_TRANSPARENCY_IOS"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_PERIPHERAL_IOS"|"NanoflowCommons.Enum_Permissions.CAMERA_IOS"|"NanoflowCommons.Enum_Permissions.CALENDARS_IOS"|"NanoflowCommons.Enum_Permissions.CONTACTS_IOS"|"NanoflowCommons.Enum_Permissions.FACE_ID_IOS"|"NanoflowCommons.Enum_Permissions.LOCATION_ALWAYS_IOS"|"NanoflowCommons.Enum_Permissions.LOCATION_WHEN_IN_USE_IOS"|"NanoflowCommons.Enum_Permissions.MEDIA_LIBRARY_IOS"|"NanoflowCommons.Enum_Permissions.MICROPHONE_IOS"|"NanoflowCommons.Enum_Permissions.MOTION_IOS"|"NanoflowCommons.Enum_Permissions.PHOTO_LIBRARY_IOS"|"NanoflowCommons.Enum_Permissions.PHOTO_LIBRARY_ADD_ONLY_IOS"|"NanoflowCommons.Enum_Permissions.REMINDERS_IOS"|"NanoflowCommons.Enum_Permissions.SIRI_IOS"|"NanoflowCommons.Enum_Permissions.SPEECH_RECOGNITION_IOS"|"NanoflowCommons.Enum_Permissions.STOREKIT_IOS"|"NanoflowCommons.Enum_Permissions.ACCEPT_HANDOVER_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_BACKGROUND_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_COARSE_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_FINE_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACCESS_MEDIA_LOCATION_ANDROID"|"NanoflowCommons.Enum_Permissions.ACTIVITY_RECOGNITION_ANDROID"|"NanoflowCommons.Enum_Permissions.ADD_VOICEMAIL_ANDROID"|"NanoflowCommons.Enum_Permissions.ANSWER_PHONE_CALLS_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_ADVERTISE_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_CONNECT_ANDROID"|"NanoflowCommons.Enum_Permissions.BLUETOOTH_SCAN_ANDROID"|"NanoflowCommons.Enum_Permissions.BODY_SENSORS_ANDROID"|"NanoflowCommons.Enum_Permissions.CALL_PHONE_ANDROID"|"NanoflowCommons.Enum_Permissions.CAMERA_ANDROID"|"NanoflowCommons.Enum_Permissions.GET_ACCOUNTS_ANDROID"|"NanoflowCommons.Enum_Permissions.PROCESS_OUTGOING_CALLS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CALENDAR_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CALL_LOG_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_CONTACTS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_EXTERNAL_STORAGE_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_PHONE_NUMBERS_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_PHONE_STATE_ANDROID"|"NanoflowCommons.Enum_Permissions.READ_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_MMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.RECEIVE_WAP_PUSH_ANDROID"|"NanoflowCommons.Enum_Permissions.RECORD_AUDIO_ANDROID"|"NanoflowCommons.Enum_Permissions.SEND_SMS_ANDROID"|"NanoflowCommons.Enum_Permissions.USE_SIP_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CALENDAR_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CALL_LOG_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_CONTACTS_ANDROID"|"NanoflowCommons.Enum_Permissions.WRITE_EXTERNAL_STORAGE_ANDROID"|"NanoflowCommons.Enum_Permissions.SCHEDULE_EXACT_ALARM_ANDROID"} permission - This field is required.
  * @returns {Promise.<"NanoflowCommons.Enum_PermissionStatus.unavailable"|"NanoflowCommons.Enum_PermissionStatus.denied"|"NanoflowCommons.Enum_PermissionStatus.limited"|"NanoflowCommons.Enum_PermissionStatus.granted"|"NanoflowCommons.Enum_PermissionStatus.blocked">}
  */
-export async function RequestGenericPermission(
+export async function CheckGenericPermission(
     permission?: string
 ): Promise<"unavailable" | "blocked" | "denied" | "granted" | "limited"> {
     // BEGIN USER CODE
@@ -95,21 +75,9 @@ export async function RequestGenericPermission(
         return Promise.resolve("unavailable");
     }
 
-    const permissionStatus =
-        mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
+
+    return mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
             ? await checkScheduleAlarm()
             : await check(mappedPermissionName as Permission);
-
-    switch (permissionStatus) {
-        case RESULTS.GRANTED:
-        case RESULTS.UNAVAILABLE:
-        case RESULTS.LIMITED:
-            return permissionStatus;
-        case RESULTS.BLOCKED:
-            handleBlockedPermission(permission);
-            return RESULTS.BLOCKED;
-        case RESULTS.DENIED:
-            return request(mappedPermissionName as Permission);
-    }
     // END USER CODE
 }

--- a/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/permissions/CheckGenericPermission.ts
@@ -6,11 +6,7 @@
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
 import { Platform, NativeModules } from "react-native";
-import {
-    check,
-    Permission,
-    PERMISSIONS as RNPermissions
-} from "react-native-permissions";
+import { check, Permission, PERMISSIONS as RNPermissions } from "react-native-permissions";
 import { ANDROIDPermissionName, IOSPermissionName } from "../../typings/RequestGenericPermission";
 
 // BEGIN EXTRA CODE
@@ -75,9 +71,8 @@ export async function CheckGenericPermission(
         return Promise.resolve("unavailable");
     }
 
-
     return mappedPermissionName === PERMISSIONS.ANDROID.SCHEDULE_EXACT_ALARM
-            ? await checkScheduleAlarm()
-            : await check(mappedPermissionName as Permission);
+        ? checkScheduleAlarm()
+        : check(mappedPermissionName as Permission);
     // END USER CODE
 }

--- a/packages/jsActions/mobile-resources-native/typings/RequestGenericPermission.d.ts
+++ b/packages/jsActions/mobile-resources-native/typings/RequestGenericPermission.d.ts
@@ -50,4 +50,5 @@ export type ANDROIDPermissionName =
     | "WRITE_CALENDAR"
     | "WRITE_CALL_LOG"
     | "WRITE_CONTACTS"
-    | "WRITE_EXTERNAL_STORAGE";
+    | "WRITE_EXTERNAL_STORAGE"
+    | "SCHEDULE_EXACT_ALARM";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12730,6 +12730,7 @@ __metadata:
     react-native-localize: 1.4.2
     react-native-permissions: 3.3.1
     react-native-push-notification: 8.1.1
+    react-native-schedule-exact-alarm-permission: ^0.1.3
     react-native-sound: 0.11.0
     react-native-touch-id: 4.4.1
     rimraf: ^2.7.1
@@ -15058,6 +15059,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: b2c3e599729f80a6339889daf872f64206ca7960c10b5f4a3ac12a047690b27ec4e19abf73c9069411b6987fdad8fea15c79acbb61332342b9e959f69f84c217
+  languageName: node
+  linkType: hard
+
+"react-native-schedule-exact-alarm-permission@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "react-native-schedule-exact-alarm-permission@npm:0.1.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: cadb1c6d17588beab4532cde73eeb943f4bf1ebb08e9e52d3cd291d3674a6d9b84ec8a590b6ff24e4fd8b671e342a12cf81b35ef4d46e927cf321442340480ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ✅ 
-   Compatible with: MX  9️⃣
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS  ❌
-   Works in Tablet ❌

#### Feature specific

-   Comply with designs ✅ 
-   Comply with PM's requirements ✅ 

## This PR contains

-   [ ] Feature
-   [ ] Documentation

## Relevant changes

I've added check and request EXACT_ALARM_PERMISSION to RequestGenericPermission. Current version of "react-native-permission" doesnt support SCHEDULE_EXACT_ALARM for Android, so I've added it using another library and combined with already existing functions. This permission is enabled by default on Android API SDK <= 33, but targeting 34 (Android 14) it's became disabled. To ensure that local notifications will work on Android 14, we have to add manual permission request.

