### PR TITLE
fix(image-native): click enlarged to close

### DIFF
--- a/packages/pluggableWidgets/image-native/src/components/ImageComponents.tsx
+++ b/packages/pluggableWidgets/image-native/src/components/ImageComponents.tsx
@@ -260,7 +260,7 @@ export const ImageEnlarged: FunctionComponent<ImageEnlargedProps> = props => {
                 style={styles.backdrop}
             >
                 <Pressable
-                    onPress={null}
+                    onPress={() => setEnlarged(false)}
                     style={{
                         // The child (FastImage) needs "flexGrow: 1" so images on Android are not blurry.
                         // Therefore we explicitly have to set width / height here to prevent the image from taking up the whole screen, which in turn prevents the user from closing the modal (bc parent Pressable will not be clickable).


### PR DESCRIPTION
When the “On click type” is set to ‘Enlarge’ the image will be enlarged when clicked on, as expected.

To close the modal, click on the backdrop; however, the backdrop could be very small on images in the same ratio as the screen, making it nearly impossible to close the enlargement. 

Expected behaviour: When clicking on the enlarged image, it will close, too.

Fixes support ticket https://support.mendix.com/hc/en-us/requests/220159

![Image_Click_Area](https://github.com/mendix/native-widgets/assets/6724749/5c831858-3976-40d4-ad34-717692c5a3ef)
