### PR TITLE
MOO-1598 - 10.12 | fix: replaced safe area view package from another reliable third party

### DIFF
--- a/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
@@ -13,7 +13,7 @@ import { extractFilters } from "./utils/filters";
 import { FilterCondition } from "mendix/filters";
 import { Gallery as GalleryComponent, GalleryProps as GalleryComponentProps } from "./components/Gallery";
 import { GalleryProps } from "../typings/GalleryProps";
-import { ObjectItem, ValueStatus } from "mendix";
+import { ObjectItem } from "mendix";
 
 export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
     const viewStateFilters = useRef<FilterCondition | undefined>(undefined);
@@ -28,18 +28,6 @@ export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
             props.datasource.setLimit(props.pageSize);
         }
     }, [props.datasource, props.pageSize]);
-
-    useEffect(() => {
-        if (props.datasource.status === ValueStatus.Available) {
-            return;
-        }
-        const intervalId = setInterval(() => {
-            props.datasource.reload();
-            if (props.datasource.status === ValueStatus.Available) {
-                clearInterval(intervalId); // Break the interval
-            }
-        }, 1000);
-    }, [props.datasource.items]);
 
     useEffect(() => {
         if (props.datasource.filter && !filtered && !viewStateFilters.current) {

--- a/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-native/src/Gallery.tsx
@@ -13,7 +13,7 @@ import { extractFilters } from "./utils/filters";
 import { FilterCondition } from "mendix/filters";
 import { Gallery as GalleryComponent, GalleryProps as GalleryComponentProps } from "./components/Gallery";
 import { GalleryProps } from "../typings/GalleryProps";
-import { ObjectItem } from "mendix";
+import { ObjectItem, ValueStatus } from "mendix";
 
 export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
     const viewStateFilters = useRef<FilterCondition | undefined>(undefined);
@@ -28,6 +28,18 @@ export const Gallery = (props: GalleryProps<GalleryStyle>): ReactElement => {
             props.datasource.setLimit(props.pageSize);
         }
     }, [props.datasource, props.pageSize]);
+
+    useEffect(() => {
+        if (props.datasource.status === ValueStatus.Available) {
+            return;
+        }
+        const intervalId = setInterval(() => {
+            props.datasource.reload();
+            if (props.datasource.status === ValueStatus.Available) {
+                clearInterval(intervalId); // Break the interval
+            }
+        }, 1000);
+    }, [props.datasource.items]);
 
     useEffect(() => {
         if (props.datasource.filter && !filtered && !viewStateFilters.current) {

--- a/packages/pluggableWidgets/safe-area-view-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/safe-area-view-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Fixed
+
+-   We fixed the issue where the user closed popup, safe area view wasn't working properly.
+
 ## [2.2.0] - 2022-04-07
 
 ### Added

--- a/packages/pluggableWidgets/safe-area-view-native/package.json
+++ b/packages/pluggableWidgets/safe-area-view-native/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@mendix/piw-native-utils-internal": "*",
     "@mendix/piw-utils-internal": "*",
-    "react-native-safe-area-context": "^4.14.0"
+    "react-native-safe-area-context": "3.1.8"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": "^9.0.0",

--- a/packages/pluggableWidgets/safe-area-view-native/package.json
+++ b/packages/pluggableWidgets/safe-area-view-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-area-view-native",
   "widgetName": "SafeAreaView",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@mendix/piw-native-utils-internal": "*",
-    "@mendix/piw-utils-internal": "*"
+    "@mendix/piw-utils-internal": "*",
+    "react-native-safe-area-context": "^4.14.0"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": "^9.0.0",

--- a/packages/pluggableWidgets/safe-area-view-native/src/SafeAreaView.tsx
+++ b/packages/pluggableWidgets/safe-area-view-native/src/SafeAreaView.tsx
@@ -1,5 +1,6 @@
 import { createElement } from "react";
-import { SafeAreaView as ReactSaveAreaView, View } from "react-native";
+import { View } from "react-native";
+import { SafeAreaView as ReactSaveAreaView } from "react-native-safe-area-context";
 import { flattenStyles } from "@mendix/piw-native-utils-internal";
 
 import { SafeAreaViewStyle, defaultSafeAreaViewStyle } from "./ui/Styles";

--- a/packages/pluggableWidgets/safe-area-view-native/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
+++ b/packages/pluggableWidgets/safe-area-view-native/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Safe area view renders with content 1`] = `
-<View
+<RNCSafeAreaView
   pointerEvents="box-none"
   style={
     {
@@ -23,11 +23,11 @@ exports[`Safe area view renders with content 1`] = `
       Content
     </Text>
   </View>
-</View>
+</RNCSafeAreaView>
 `;
 
 exports[`Safe area view renders with custom styling 1`] = `
-<View
+<RNCSafeAreaView
   pointerEvents="box-none"
   style={
     {
@@ -50,11 +50,11 @@ exports[`Safe area view renders with custom styling 1`] = `
       Content
     </Text>
   </View>
-</View>
+</RNCSafeAreaView>
 `;
 
 exports[`Safe area view renders without content 1`] = `
-<View
+<RNCSafeAreaView
   pointerEvents="box-none"
   style={
     {
@@ -72,5 +72,5 @@ exports[`Safe area view renders without content 1`] = `
       }
     }
   />
-</View>
+</RNCSafeAreaView>
 `;

--- a/packages/pluggableWidgets/safe-area-view-native/src/package.xml
+++ b/packages/pluggableWidgets/safe-area-view-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="SafeAreaView" version="2.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="SafeAreaView" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="SafeAreaView.xml" />
         </widgetFiles>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14952,6 +14952,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-safe-area-context@npm:^4.14.0":
+  version: 4.14.1
+  resolution: "react-native-safe-area-context@npm:4.14.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: acf94ea2a30a3ec5594b467f8e0942ac48c10cbb5d34d16beba33cc0052f7c82dfd6ace754fa55f41d55143f134d3d3fa908eaf4cc9dec5743d6c4483b23520a
+  languageName: node
+  linkType: hard
+
 "react-native-schedule-exact-alarm-permission@npm:^0.1.3":
   version: 0.1.4
   resolution: "react-native-schedule-exact-alarm-permission@npm:0.1.4"
@@ -15846,6 +15856,7 @@ __metadata:
     "@mendix/piw-utils-internal": "*"
     "@mendix/pluggable-widgets-tools": ^9.0.0
     eslint: ^7.20.0
+    react-native-safe-area-context: ^4.14.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14952,13 +14952,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^4.14.0":
-  version: 4.14.1
-  resolution: "react-native-safe-area-context@npm:4.14.1"
+"react-native-safe-area-context@npm:3.1.8":
+  version: 3.1.8
+  resolution: "react-native-safe-area-context@npm:3.1.8"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: acf94ea2a30a3ec5594b467f8e0942ac48c10cbb5d34d16beba33cc0052f7c82dfd6ace754fa55f41d55143f134d3d3fa908eaf4cc9dec5743d6c4483b23520a
+  checksum: 4bcbd77ffe3b1ae264b784c1d318e2904e6fce572d573b5974eb8d325a990b053bce2e265d1ff0bb4d14a7dcf73805f931ac3d4a4a7751360b4f955e069c9569
   languageName: node
   linkType: hard
 
@@ -15856,7 +15856,7 @@ __metadata:
     "@mendix/piw-utils-internal": "*"
     "@mendix/pluggable-widgets-tools": ^9.0.0
     eslint: ^7.20.0
-    react-native-safe-area-context: ^4.14.0
+    react-native-safe-area-context: 3.1.8
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I replaced our safe area view resource from react native to react-native-safe-area-context.

After opening popup, our current safe-area-view was causing issue and the people in the [comment](https://github.com/react-navigation/react-navigation/issues/11664) suggested to use different package.

It's well supported third party package.