### PR TITLE
chore: bump the version of the react native progress

### DIFF
--- a/packages/pluggableWidgets/progress-bar-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/progress-bar-native/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   Bumped the version of the react-native-progress.
+
 ## [4.3.0] - 2024-12-3
 
 ### Changed

--- a/packages/pluggableWidgets/progress-bar-native/package.json
+++ b/packages/pluggableWidgets/progress-bar-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "progress-bar-native",
   "widgetName": "ProgressBar",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mendix/piw-native-utils-internal": "*",
     "@mendix/piw-utils-internal": "1.0.0",
-    "react-native-progress": "^5.0.0"
+    "react-native-progress": "^5.0.1"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": "~10.0.1",

--- a/packages/pluggableWidgets/progress-bar-native/src/package.xml
+++ b/packages/pluggableWidgets/progress-bar-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ProgressBar" version="4.3.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ProgressBar" version="4.3.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="ProgressBar.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/progress-circle-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/progress-circle-native/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   Bumped the version of the react-native-progress.
+
 ## [3.2.0] - 2024-12-3
 
 ### Changed

--- a/packages/pluggableWidgets/progress-circle-native/package.json
+++ b/packages/pluggableWidgets/progress-circle-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "progress-circle-native",
   "widgetName": "ProgressCircle",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@mendix/piw-native-utils-internal": "*",
-    "react-native-progress": "^5.0.0"
+    "react-native-progress": "^5.0.1"
   },
   "devDependencies": {
     "@mendix/piw-utils-internal": "*",

--- a/packages/pluggableWidgets/progress-circle-native/src/package.xml
+++ b/packages/pluggableWidgets/progress-circle-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ProgressCircle" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ProgressCircle" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="ProgressCircle.xml" />
         </widgetFiles>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15378,7 +15378,7 @@ __metadata:
     "@mendix/pluggable-widgets-tools": "npm:~10.0.1"
     detox: "npm:^19.13.0"
     eslint: "npm:^7.32.0"
-    react-native-progress: "npm:^5.0.0"
+    react-native-progress: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 
@@ -15391,7 +15391,7 @@ __metadata:
     "@mendix/pluggable-widgets-tools": "npm:~10.0.1"
     detox: "npm:^19.13.0"
     eslint: "npm:^7.32.0"
-    react-native-progress: "npm:^5.0.0"
+    react-native-progress: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 
@@ -15984,14 +15984,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-progress@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "react-native-progress@npm:5.0.0"
+"react-native-progress@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "react-native-progress@npm:5.0.1"
   dependencies:
     prop-types: "npm:^15.7.2"
   peerDependencies:
     react-native-svg: "*"
-  checksum: 10/b55a4826fd5aa680a7cbbfc653ff4338230249f5b86f0c82d263f2d20737e19fadb04639e36d9f45cf61df524bb5875a27783d47374f39426ba6aecc471a1dcf
+  checksum: 10/902189578ce233bbc3cb3a85c13d4bcd439430e1a3da7bcf622e00ff6a2404155b22ce3c3350ccdb5b50952746b99f8522404a818531472250b60b75975a524c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Checklist
Fix the black filling issue because of the new version of react-native-svg

## This PR contains

-   [X] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

