### PR TITLE
[MOO-1887]: Fix initial slide positioning in IntroScreen widget [MX 11]

### DIFF
--- a/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixes
+
+-   Initial slide now correctly positioned on mount.
+
+### Changed
+
 -   Updated react-native-device-info to latest version.
 
 ### Fixed

--- a/packages/pluggableWidgets/intro-screen-native/package.json
+++ b/packages/pluggableWidgets/intro-screen-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intro-screen-native",
   "widgetName": "IntroScreen",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/intro-screen-native/src/IntroScreen.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/IntroScreen.tsx
@@ -24,33 +24,33 @@ export function IntroScreen(props: IntroScreenProps<IntroScreenStyle>): JSX.Elem
         } else {
             setVisible(true);
         }
-    }, []);
+    }, [props.identifier]);
+
+    const hideModal = useCallback((): void => {
+        if (props.identifier) {
+            AsyncStorage.setItem(props.identifier, "gone").then(() => setVisible(false));
+        } else {
+            setVisible(false);
+        }
+    }, [props.identifier]);
 
     const onDone = useCallback(() => {
         hideModal();
         executeAction(props.onDone);
-    }, [props.onDone]);
+    }, [hideModal, props.onDone]);
 
     const onSlideChange = useCallback(() => executeAction(props.onSlideChange), [props.onSlideChange]);
 
     const onSkip = useCallback(() => {
         hideModal();
         executeAction(props.onSkip);
-    }, [props.onSkip]);
+    }, [hideModal, props.onSkip]);
 
     const checkLabel = (label?: DynamicValue<string>): string | undefined => {
         if (label && label.value && label.status === ValueStatus.Available) {
             return label.value;
         }
         return undefined;
-    };
-
-    const hideModal = (): void => {
-        if (props.identifier) {
-            AsyncStorage.setItem(props.identifier, "gone").then(() => setVisible(false));
-        } else {
-            setVisible(false);
-        }
     };
 
     const showSkipPrevious = props.buttonPattern === "all";

--- a/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
@@ -8,7 +8,9 @@ import {
     StyleSheet,
     Text,
     TouchableNativeFeedback,
+    TouchableNativeFeedbackProps,
     TouchableOpacity,
+    TouchableOpacityProps,
     View
 } from "react-native";
 import { ButtonStyle, IntroScreenStyle } from "./ui/Styles";
@@ -43,10 +45,13 @@ interface SwipeableContainerProps {
     activeSlide?: EditableValue<Big>;
 }
 
+type TouchableProps = TouchableNativeFeedbackProps | TouchableOpacityProps;
+
 declare type Option<T> = T | undefined;
 
 const isAndroidRTL = I18nManager.isRTL && Platform.OS === "android";
-const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
+const Touchable: React.ComponentType<TouchableProps> =
+    Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
 const refreshActiveSlideAttribute = (slides: SlidesType[], activeSlide?: EditableValue<Big>): number => {
     if (activeSlide && activeSlide.status === ValueStatus.Available && slides && slides.length > 0) {
@@ -66,12 +71,10 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
     const [activeIndex, setActiveIndex] = useState(0);
     const flatList = useRef<FlatList<any>>(null);
 
-    useEffect(() => {
-        const slide = refreshActiveSlideAttribute(props.slides, props.activeSlide);
-        if (width && props.activeSlide && props.activeSlide.status === ValueStatus.Available && slide !== activeIndex) {
-            goToSlide(slide);
-        }
-    }, [props.activeSlide, activeIndex, width]);
+    const rtlSafeIndex = useCallback(
+        (i: number): number => (isAndroidRTL ? props.slides.length - 1 - i : i),
+        [props.slides.length]
+    );
 
     const goToSlide = useCallback(
         (pageNum: number) => {
@@ -82,8 +85,15 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
                 });
             }
         },
-        [width, flatList]
+        [rtlSafeIndex, width]
     );
+
+    useEffect(() => {
+        const slide = refreshActiveSlideAttribute(props.slides, props.activeSlide);
+        if (width && props.activeSlide && props.activeSlide.status === ValueStatus.Available && slide !== activeIndex) {
+            goToSlide(slide);
+        }
+    }, [props.activeSlide, activeIndex, width, props.slides, goToSlide]);
 
     const onNextPress = (): void => {
         goToSlide(activeIndex + 1);
@@ -278,11 +288,6 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
         );
     };
 
-    const rtlSafeIndex = useCallback(
-        (i: number): number => (isAndroidRTL ? props.slides.length - 1 - i : i),
-        [props.slides.length]
-    );
-
     const onMomentumScrollEnd = useCallback(
         (event: NativeSyntheticEvent<any>) => {
             const offset = event.nativeEvent.contentOffset.x;
@@ -314,6 +319,8 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
         <View style={styles.flexOne}>
             <FlatList
                 testID={props.testID}
+                initialScrollIndex={refreshActiveSlideAttribute(props.slides, props.activeSlide)}
+                getItemLayout={(_, i) => ({ length: width, offset: width * i, index: i })}
                 ref={flatList}
                 data={props.slides}
                 horizontal

--- a/packages/pluggableWidgets/intro-screen-native/src/package.xml
+++ b/packages/pluggableWidgets/intro-screen-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="IntroScreen" version="4.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="IntroScreen" version="4.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="IntroScreen.xml" />
         </widgetFiles>


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Compatible with: MX 11
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 


## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Currently, when activeSlide is set to a non-zero value, the IntroScreen always opens on the first slide. This happens because the effect that calls scrollToOffset runs too late (or not at all) and its dependency array doesn’t include the slide value/status, so the FlatList never scrolls to the desired index on mount.

