### PR TITLE
chore: remove react-native-system-navigation-bar

### DIFF
--- a/configs/e2e/native_dependencies.json
+++ b/configs/e2e/native_dependencies.json
@@ -7,7 +7,6 @@
     "react-native-linear-gradient": "2.8.3",
     "@react-native-community/netinfo": "11.4.1",
     "react-native-svg": "15.11.1",
-    "react-native-system-navigation-bar": "2.6.3",
     "react-native-video": "6.10.0",
     "@react-native-async-storage/async-storage": "2.0.0",
     "react-native-camera": "3.40.0",

--- a/packages/pluggableWidgets/video-player-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We have removed react-native-system-navigation-bar and deprecated-react-native-prop-types dependencies. Navigation bar visibility is now handled by the react-native-video package.
+
 ## [6.2.0] - 2025-08-18
 
 ### Changed

--- a/packages/pluggableWidgets/video-player-native/package.json
+++ b/packages/pluggableWidgets/video-player-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video-player-native",
   "widgetName": "VideoPlayer",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "@mendix/piw-native-utils-internal": "*",
-    "deprecated-react-native-prop-types": "^4.0.0",
-    "react-native-system-navigation-bar": "2.6.3",
     "react-native-vector-icons": "10.2.0",
     "react-native-video": "6.10.0"
   },

--- a/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
@@ -86,13 +86,9 @@ export function VideoPlayer(props: VideoPlayerProps<VideoStyle>): ReactElement {
         setFullScreen(isFullScreen);
         const { NavigationBar } = NativeModules;
         if (NavigationBar) {
-            const SystemNavigationBar = (await import("react-native-system-navigation-bar")).default;
-
             if (isFullScreen) {
-                SystemNavigationBar.navigationHide();
                 StatusBar.setHidden(true);
             } else {
-                SystemNavigationBar.navigationShow();
                 StatusBar.setHidden(false);
                 const isDark = Appearance.getColorScheme() === "dark";
                 StatusBar.setBarStyle(isDark ? "light-content" : "dark-content");

--- a/packages/pluggableWidgets/video-player-native/src/__tests__/VideoPlayer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-native/src/__tests__/VideoPlayer.spec.tsx
@@ -10,10 +10,6 @@ import { VideoStyle } from "../ui/Styles";
 
 jest.useFakeTimers();
 jest.mock("react-native-video", () => "Video");
-jest.mock("react-native-system-navigation-bar", () => ({
-    navigationHide: jest.fn(),
-    navigationShow: jest.fn()
-}));
 
 describe("VideoPlayer", () => {
     let defaultProps: VideoPlayerProps<VideoStyle>;

--- a/packages/pluggableWidgets/video-player-native/src/package.xml
+++ b/packages/pluggableWidgets/video-player-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="6.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="6.3.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="VideoPlayer.xml" />
         </widgetFiles>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,12 +888,6 @@ importers:
       '@mendix/piw-native-utils-internal':
         specifier: '*'
         version: link:../../tools/piw-native-utils-internal
-      deprecated-react-native-prop-types:
-        specifier: ^4.0.0
-        version: 4.2.3
-      react-native-system-navigation-bar:
-        specifier: 2.6.3
-        version: 2.6.3(react-native@0.77.3(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.23)(react@18.2.0))(react@18.2.0)
       react-native-vector-icons:
         specifier: 10.2.0
         version: 10.2.0
@@ -6572,12 +6566,6 @@ packages:
 
   react-native-svg@15.7.1:
     resolution: {integrity: sha512-Xc11L4t6/DtmUwrQqHR7S45Qy3cIWpcfGlmEatVeZ9c1N8eAK79heJmGRgCOVrXESrrLEHfP/AYGf0BGyrvV6A==}
-    peerDependencies:
-      react: 18.2.0
-      react-native: 0.77.3
-
-  react-native-system-navigation-bar@2.6.3:
-    resolution: {integrity: sha512-QzKVdIkDfwziJQA5PEHPJhT2/WCioWaNaXOg0HpzLAX5XlSdirnfz3riWJB9Zrj/RdWIt+qZGihkw5zTdYA3uA==}
     peerDependencies:
       react: 18.2.0
       react-native: 0.77.3
@@ -15093,11 +15081,6 @@ snapshots:
       react: 18.2.0
       react-native: 0.77.3(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.23)(react@18.2.0)
       warn-once: 0.1.1
-
-  react-native-system-navigation-bar@2.6.3(react-native@0.77.3(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.23)(react@18.2.0))(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      react-native: 0.77.3(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.23)(react@18.2.0)
 
   react-native-vector-icons@10.2.0:
     dependencies:


### PR DESCRIPTION
## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other - Remove react-native-system-navigation-bar and deprecated-react-native-prop-types dependencies