### PR TITLE
[OFF-784]: Use xas-info to check if we are connected to the server

### DIFF
--- a/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   We've fixed location permission issue on iOS.
+-   We've fixed isConnectedToServer succeeding without internet on offline apps when service worker is enabled.
 
 ### Changed
 

--- a/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
+++ b/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
@@ -5,8 +5,6 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
-import "mx-global";
-import { Big } from "big.js";
 
 // BEGIN EXTRA CODE
 // END EXTRA CODE
@@ -14,7 +12,7 @@ import { Big } from "big.js";
 /**
  * @returns {Promise.<boolean>}
  */
-export async function IsConnectedToServer() {
+export async function IsConnectedToServer(): Promise<boolean> {
     // BEGIN USER CODE
     try {
         const headers = new Headers();

--- a/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
+++ b/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
@@ -15,24 +15,24 @@ import { Big } from "big.js";
  * @returns {Promise.<boolean>}
  */
 export async function IsConnectedToServer() {
-	// BEGIN USER CODE
+    // BEGIN USER CODE
     try {
         const headers = new Headers();
         headers.append("Content-Type", "application/json");
-        const body = JSON.stringify({ "action": "info" });
+        const body = JSON.stringify({ action: "info" });
 
         const requestOptions = {
-            method: 'POST',
+            method: "POST",
             headers,
-            body,
+            body
         };
 
         // mx.remoteUrl always has / at the end, therefore we don't add it.
         const response = await fetch(`${mx.remoteUrl}xas/`, requestOptions);
         return response.ok;
-    }
-    catch (err) {
+    } catch (err) {
+        console.error(err);
         return false;
     }
-	// END USER CODE
+    // END USER CODE
 }

--- a/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
+++ b/packages/jsActions/nanoflow-actions-native/src/client/IsConnectedToServer.ts
@@ -5,6 +5,8 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
+import "mx-global";
+import { Big } from "big.js";
 
 // BEGIN EXTRA CODE
 // END EXTRA CODE
@@ -12,14 +14,25 @@
 /**
  * @returns {Promise.<boolean>}
  */
-export async function IsConnectedToServer(): Promise<boolean> {
-    // BEGIN USER CODE
+export async function IsConnectedToServer() {
+	// BEGIN USER CODE
     try {
-        const response = await fetch(mx.remoteUrl);
+        const headers = new Headers();
+        headers.append("Content-Type", "application/json");
+        const body = JSON.stringify({ "action": "info" });
+
+        const requestOptions = {
+            method: 'POST',
+            headers,
+            body,
+        };
+
+        // mx.remoteUrl always has / at the end, therefore we don't add it.
+        const response = await fetch(`${mx.remoteUrl}xas/`, requestOptions);
         return response.ok;
-    } catch (err) {
-        console.error(err);
+    }
+    catch (err) {
         return false;
     }
-    // END USER CODE
+	// END USER CODE
 }


### PR DESCRIPTION
## Checklist

-   Contains breaking changes ❌
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

## This PR contains

-   [X] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

To use a proper endpoint to check if we are connected to the server. The existing request can be cached when service workers are used.

## Relevant changes

We use an xas action to prevent the response to be interpreted by the service worker.

## What should be covered while testing?

isConnectedToServer jsAction needs to be tested
