### PR TITLE
fix: update labeler configuration

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,12 +1,18 @@
 documentation:
-  - all: ["*.md"]
+  - changed-files:
+      - any-glob-to-all-files: ["*.md"]
 Core:
-  - .github/**/*
-  - .husky/**/*
-  - data/**/*
-  - scripts/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**/*
+          - .husky/**/*
+          - data/**/*
+          - scripts/**/*
 Widget:
-  - packages/**/*-native*/**/*
-  - packages/**/*_native*/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/**/*-native*/**/*
+          - packages/**/*_native*/**/*
 test:
-  - all: ["*.spec.*"]
+  - changed-files:
+      - any-glob-to-all-files: ["*.spec.*"]


### PR DESCRIPTION
The latest labeler action introduced a syntax change. It didn’t fail earlier because it reads the config from the target branch, but after merging the last changes it started complaining.
This PR fixes the syntax. 
I’ve tested it on a fork [here](https://github.com/YogendraShelke/native-widgets/pull/7)