### PR TITLE
[MOO-2145]: fix Range Slider skipped test 

### DIFF
--- a/packages/pluggableWidgets/range-slider-native/src/__tests__/RangeSlider.spec.tsx
+++ b/packages/pluggableWidgets/range-slider-native/src/__tests__/RangeSlider.spec.tsx
@@ -134,11 +134,6 @@ describe("RangeSlider", () => {
         expect(component.getAllByText("Invalid")).toHaveLength(2);
     });
 
-    it.skip("handles an invalid step size", () => {
-        const component = render(<RangeSlider {...defaultProps} stepSize={dynamicValue(new Big(-10))} />);
-        expect(component.getByTestId("range-slider-test").findByProps({ step: 1 })).not.toBeNull();
-    });
-
     it("changes the lower value when swiping", () => {
         const onChangeAction = actionValue();
         const component = render(<RangeSlider {...defaultProps} onChange={onChangeAction} />);


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ✅ 
-   Compatible with: MX 8, 9, 10
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

The skipped test was expecting incorrect behavior that never existed in the implementation. It assumed the component would default to step: 1 when given an invalid (negative) step size, but the component has always validated this and shown an error message instead. 

## Relevant changes

Removed the skipped test completely.