### PR TITLE
[MOO-2224]: Intro Screen TalkBack/VoiceOver fix

### DIFF
--- a/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with the TalkBack/VoiceOver traversal in the IntroScreen widget, where the order was not correct.
+
 ## [4.3.0] - 2026-4-9
 
 ### Changed

--- a/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
@@ -124,10 +124,19 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
     };
 
     const renderItem = useCallback(
-        ({ item }: any): ReactElement => {
-            return <View style={[{ width }, { height }]}>{item.content}</View>;
+        ({ item, index }: any): ReactElement => {
+            const isActive = index === activeIndex;
+            return (
+                <View
+                    style={[{ width, flex: 1 }]}
+                    importantForAccessibility={isActive ? "auto" : "no-hide-descendants"}
+                    accessibilityElementsHidden={!isActive}
+                >
+                    {item.content}
+                </View>
+            );
         },
-        [width, height]
+        [width, height, activeIndex]
     );
 
     const renderButton = (
@@ -284,6 +293,9 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
                                         : props.styles.dotStyle
                                 ]}
                                 onPress={() => onPaginationPress(i)}
+                                accessibilityRole="button"
+                                accessibilityLabel={`Go to slide ${i + 1}`}
+                                accessibilityState={{ selected: rtlSafeIndex(i) === activeIndex }}
                             />
                         ))}
                     {!hidePagination && paginationOverflow && (
@@ -356,9 +368,10 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
                 renderItem={renderItem}
                 onMomentumScrollEnd={onMomentumScrollEnd}
                 scrollEventThrottle={50}
-                extraData={width}
+                extraData={[width, activeIndex]}
                 onLayout={onLayout}
                 keyExtractor={(_: any, index: number) => "screen_key_" + index}
+                importantForAccessibility="no"
             />
             {renderPagination()}
         </View>


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Compatible with: MX 11
-   Works in Android ✅
-   Works in iOS ✅
-   Works in Tablet ✅

#### Feature specific

-   Comply with designs ✅
-   Comply with PM's requirements ✅

## This PR contains

-   [X] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR addresses an issue with the TalkBack/VoiceOver accessibility feature when using the IntroScreen widget. The order of traversing the slides and pagination section for each slide was incorrect.

## Relevant changes

Added conditional accessibility for slides depending on the active slide and added accessibility labels for the pagination buttons.

## What should be covered while testing?

The TalkBack and VoiceOver feature when using the Intro Screen widget with 2+ slides.