### PR TITLE
fix: correct param name for split action

### DIFF
--- a/.github/workflows/MarketplaceRelease.yml
+++ b/.github/workflows/MarketplaceRelease.yml
@@ -23,7 +23,7 @@ jobs:
         id: scope
         with:
           msg: "${{ steps.variables.outputs.tag }}"
-          seperator: "-v"
+          separator: "-v"
       - name: "Defining node version"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
Renamed the parameter to match the changes in https://github.com/winterjung/split/pull/6