### PR TITLE
Fix/maestro flow races

### DIFF
--- a/.github/workflows/NativePipeline.yml
+++ b/.github/workflows/NativePipeline.yml
@@ -751,7 +751,7 @@ jobs:
     # truncated — at 20 min several shards (accordion, background-image, bottom-sheet,
     # color-picker, safe-area-view) were cancelled mid-flow. If a shard still hits 30 the cause
     # is real app instability, not the cap.
-    timeout-minutes: 35
+    timeout-minutes: 30
     strategy:
       max-parallel: 4
       matrix:

--- a/maestro/helpers/helpers.sh
+++ b/maestro/helpers/helpers.sh
@@ -92,14 +92,48 @@ cleanup_xctest_processes() {
 }
 
 # Function to restart the iOS simulator
+#
+# This is the recovery path taken when the Maestro/XCTest driver wedges ("iOS driver not
+# ready in time"), so it has to ACTUALLY restart the device. It previously did not: the
+# shutdown result was discarded with `|| true`, and the following prepare_ios.sh reported
+#
+#     Monitoring boot status for iPhone 17 Pro (...).
+#     Device already booted, nothing to do.
+#
+# i.e. the device never went down and the shard only got an app reinstall on top of the
+# same wedged runtime. So we now verify the device reaches Shutdown and say so loudly if
+# it doesn't, rather than silently continuing with a half-reset simulator.
 restart_simulator() {
     echo "🔄 Restarting iOS Simulator..."
-    # Clean up XCTest processes first
+    # Kill the XCTest runner FIRST: while it holds the device, shutdown can fail.
     cleanup_xctest_processes
-    # Shut down whatever is booted; the device is auto-selected in prepare_ios.sh,
-    # so we don't depend on a hardcoded device name here.
-    xcrun simctl shutdown all || true
-    sleep 10
+
+    # Target the device prepare_ios.sh selected when we know it; `all` otherwise (first
+    # call in a shard, where SIMULATOR_DEVICE_ID isn't exported into this shell yet).
+    local target="${SIMULATOR_DEVICE_ID:-all}"
+    echo "Shutting down simulator ($target)..."
+    if ! xcrun simctl shutdown "$target" 2>&1; then
+        # Already-shutdown is a benign error, so don't fail here — the poll below is what
+        # decides whether the device is actually down.
+        echo "shutdown reported an error; verifying device state anyway"
+    fi
+
+    # `simctl shutdown <udid>` is synchronous (measured ~3s), but poll rather than trust
+    # it: this replaces a blind `sleep 10` that padded every retry whether or not it was
+    # needed. Bounded so a stuck device surfaces as a warning instead of hanging.
+    local deadline=$((SECONDS + 30))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if [ -n "${SIMULATOR_DEVICE_ID:-}" ]; then
+            xcrun simctl list devices | grep -q "$SIMULATOR_DEVICE_ID.*Shutdown" && break
+        else
+            xcrun simctl list devices | grep -q "(Booted)" || break
+        fi
+        sleep 1
+    done
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "::warning::Simulator did not reach Shutdown within 30s; the driver may still be wedged after this restart"
+    fi
+
     bash ./maestro/helpers/prepare_ios.sh
 }
 

--- a/packages/pluggableWidgets/background-gradient-native/e2e/specs/maestro/BackgroundGradient.yaml
+++ b/packages/pluggableWidgets/background-gradient-native/e2e/specs/maestro/BackgroundGradient.yaml
@@ -5,6 +5,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background gradient"
+    timeout: 10000
 - tapOn:
     text: "Background gradient"
 - extendedWaitUntil:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_clickable_container.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_clickable_container.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_conditional_visibility.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_conditional_visibility.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_image.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_image.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_image.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_image.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Background image"
 - tapOn:
     text: "Dynamic image"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 30000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 30s.
+- waitForAnimationToEnd:
+    timeout: 30000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bg_image_dynamic_image"
 - assertScreenshot:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_svg.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_svg.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Background image"
 - tapOn:
     text: "Dynamic SVG image"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bg_image_dynamic_svg"
 - assertScreenshot:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_svg.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_dynamic_svg.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_layout_grid.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_layout_grid.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_layout_grid.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_layout_grid.yaml
@@ -14,11 +14,11 @@ appId: "${APP_ID}"
 - tapOn:
     text: "Layout grid"
 - assertVisible: "Layout grid"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bg_image_layout_grid"
 - assertScreenshot:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_nested.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_nested.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_nested.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_nested.yaml
@@ -14,11 +14,11 @@ appId: "${APP_ID}"
 - tapOn:
     text: "Nested"
 - assertVisible: "Nested"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bg_image_nested"
 - assertScreenshot:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_images.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_images.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_images.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_images.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Static images"
 - assertVisible:
     text: "Static images"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 10000 # 10 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 10s.
+- waitForAnimationToEnd:
+    timeout: 10000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bg_image_static_images"
 - assertScreenshot:

--- a/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_svg.yaml
+++ b/packages/pluggableWidgets/background-image-native/e2e/specs/maestro/BgImage_static_svg.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Background image"
+    timeout: 10000
 - tapOn:
     text: "Background image"
 - tapOn:

--- a/packages/pluggableWidgets/badge-native/e2e/specs/maestro/Badge_android.yaml
+++ b/packages/pluggableWidgets/badge-native/e2e/specs/maestro/Badge_android.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Badge"
+    timeout: 10000
 - tapOn:
     text: "Badge"
 - tapOn:

--- a/packages/pluggableWidgets/badge-native/e2e/specs/maestro/Badge_ios.yaml
+++ b/packages/pluggableWidgets/badge-native/e2e/specs/maestro/Badge_ios.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Badge"
+    timeout: 10000
 - tapOn:
     text: "Badge"
 - inputText:

--- a/packages/pluggableWidgets/bar-chart-native/e2e/specs/maestro/Bar_Chart.yaml
+++ b/packages/pluggableWidgets/bar-chart-native/e2e/specs/maestro/Bar_Chart.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Bar chart"
 - assertVisible:
     id: "container1"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bar_chart"
 - assertScreenshot:

--- a/packages/pluggableWidgets/bar-chart-native/e2e/specs/maestro/Bar_Chart.yaml
+++ b/packages/pluggableWidgets/bar-chart-native/e2e/specs/maestro/Bar_Chart.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bar chart"
+    timeout: 10000
 - tapOn:
     text: "Bar chart"
 - assertVisible:

--- a/packages/pluggableWidgets/barcode-scanner-native/e2e/specs/maestro/Barcode_scanner.yaml
+++ b/packages/pluggableWidgets/barcode-scanner-native/e2e/specs/maestro/Barcode_scanner.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Barcode scanner"
+    timeout: 10000
 - tapOn:
     text: "Barcode scanner"
 - assertVisible:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Bottom_sheet_expanding.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Bottom_sheet_expanding.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bottom Sheet"
+    timeout: 10000
 - tapOn:
     text: "Bottom Sheet"
 - tapOn:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Bottom_sheet_expanding.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Bottom_sheet_expanding.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Bottom Sheet"
 - tapOn:
     text: "Expanding"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 10000 # 10 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 10s.
+- waitForAnimationToEnd:
+    timeout: 10000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bottom_sheet_expanding"
 - assertScreenshot:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Botton_sheet_expanding_fullscreen.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Botton_sheet_expanding_fullscreen.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bottom Sheet"
+    timeout: 10000
 - tapOn:
     text: "Bottom Sheet"
 - tapOn:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Botton_sheet_expanding_fullscreen.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Botton_sheet_expanding_fullscreen.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Bottom Sheet"
 - tapOn:
     text: "Expanding fullscreen"
-# Because the image loading and animation can take some time due to resources on emulator, we need to wait
-- extendedWaitUntil:
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds to allow for animation to complete
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bottom_sheet_expanding_fullscreen"
 - assertScreenshot:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bottom Sheet"
+    timeout: 10000
 - tapOn:
     text: "Bottom Sheet"
 - tapOn:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic_non_native.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic_non_native.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bottom Sheet"
+    timeout: 10000
 - tapOn:
     text: "Bottom Sheet"
 - tapOn:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic_non_native.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_basic_non_native.yaml
@@ -20,10 +20,10 @@ appId: "${APP_ID}"
 - tapOn:
     text: "Open"
 
-# Wait until the sheet is actually open (button label changes)
-- extendedWaitUntil:
-    visible: randText
-    optional: true
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 25s.
+- waitForAnimationToEnd:
     timeout: 25000
 
 - takeScreenshot:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_custom.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_custom.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "B"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Bottom Sheet"
+    timeout: 10000
 - tapOn:
     text: "Bottom Sheet"
 - tapOn:

--- a/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_custom.yaml
+++ b/packages/pluggableWidgets/bottom-sheet-native/e2e/specs/maestro/Modal_custom.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Modal custom"
 - tapOn:
     text: "Open"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 5000 # 5 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 5s.
+- waitForAnimationToEnd:
+    timeout: 5000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/bottom_sheet_modal_custom"
 - assertScreenshot:

--- a/packages/pluggableWidgets/carousel-native/e2e/specs/maestro/Carousel.yaml
+++ b/packages/pluggableWidgets/carousel-native/e2e/specs/maestro/Carousel.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Carousel"
+    timeout: 10000
 - tapOn:
     text: "Carousel"
 - swipe:

--- a/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Conditional.yaml
+++ b/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Conditional.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Color picker"
+    timeout: 10000
 - tapOn:
     text: "Color picker"
 - tapOn:

--- a/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Disabled.yaml
+++ b/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Disabled.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Color picker"
+    timeout: 10000
 - tapOn:
     text: "Color picker"
 - tapOn:

--- a/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Normal.yaml
+++ b/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Normal.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Color picker"
+    timeout: 10000
 - tapOn:
     text: "Color picker"
 - tapOn:

--- a/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_OnChange.yaml
+++ b/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_OnChange.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Color picker"
+    timeout: 10000
 - tapOn:
     text: "Color picker"
 - tapOn:

--- a/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Partial.yaml
+++ b/packages/pluggableWidgets/color-picker-native/e2e/specs/maestro/Color_picker_native_Partial.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Color picker"
+    timeout: 10000
 - tapOn:
     text: "Color picker"
 - tapOn:

--- a/packages/pluggableWidgets/column-chart-native/e2e/specs/maestro/Column_chart_native.yaml
+++ b/packages/pluggableWidgets/column-chart-native/e2e/specs/maestro/Column_chart_native.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Column chart"
 - assertVisible:
     id: "container1"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/column_chart"
 - assertScreenshot:

--- a/packages/pluggableWidgets/column-chart-native/e2e/specs/maestro/Column_chart_native.yaml
+++ b/packages/pluggableWidgets/column-chart-native/e2e/specs/maestro/Column_chart_native.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "C"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Column chart"
+    timeout: 10000
 - tapOn:
     text: "Column chart"
 - assertVisible:

--- a/packages/pluggableWidgets/feedback-native/e2e/specs/maestro/Feedback.yaml
+++ b/packages/pluggableWidgets/feedback-native/e2e/specs/maestro/Feedback.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "F"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Feedback"
+    timeout: 10000
 - tapOn:
     text: "Feedback"
 - assertVisible:

--- a/packages/pluggableWidgets/floating-action-button-native/e2e/specs/maestro/FloatingActionButton.yaml
+++ b/packages/pluggableWidgets/floating-action-button-native/e2e/specs/maestro/FloatingActionButton.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "F"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Floating action button"
+    timeout: 10000
 - tapOn:
     text: "Floating action button"
 - tapOn:

--- a/packages/pluggableWidgets/gallery-native/e2e/specs/maestro/Gallery_native.yaml
+++ b/packages/pluggableWidgets/gallery-native/e2e/specs/maestro/Gallery_native.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "G"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Gallery"
+    timeout: 10000
 - tapOn:
     text: "Gallery"
 - tapOn:

--- a/packages/pluggableWidgets/gallery-native/e2e/specs/maestro/Gallery_native_horizontal.yaml
+++ b/packages/pluggableWidgets/gallery-native/e2e/specs/maestro/Gallery_native_horizontal.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "G"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Gallery"
+    timeout: 10000
 - tapOn:
     text: "Gallery"
 - tapOn:

--- a/packages/pluggableWidgets/gallery-text-filter-native/e2e/specs/maestro/Gallery_Text_Filter.yaml
+++ b/packages/pluggableWidgets/gallery-text-filter-native/e2e/specs/maestro/Gallery_Text_Filter.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "G"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Gallery"
+    timeout: 10000
 - tapOn:
     text: "Gallery"
 - tapOn:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_dynamic.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_dynamic.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "I"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Image"
+    timeout: 10000
 - tapOn:
     text: "Image"
 - tapOn:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_dynamic.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_dynamic.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Image"
 - tapOn:
     text: "Image dynamic"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 30000 # 30 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 30s.
+- waitForAnimationToEnd:
+    timeout: 30000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/image_dynamic"
 - assertScreenshot:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_icon.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_icon.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "I"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Image"
+    timeout: 10000
 - tapOn:
     text: "Image"
 - tapOn:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_static.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_static.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "I"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Image"
+    timeout: 10000
 - tapOn:
     text: "Image"
 - tapOn:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_static.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_static.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Image static"
 - assertVisible: 
     text: "Main as Static Image; Default as Static; Background as Contain"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/image_static"
 - assertScreenshot:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_url.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_url.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "I"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Image"
+    timeout: 10000
 - tapOn:
     text: "Image"
 - tapOn:

--- a/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_url.yaml
+++ b/packages/pluggableWidgets/image-native/e2e/specs/maestro/Image_url.yaml
@@ -14,11 +14,11 @@ appId: "${APP_ID}"
 - tapOn:
     text: "Image url"
 - assertVisible: "Main as Image URL(svg); Background as No; Action as Open dialog box"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 20000 # 20 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 20s.
+- waitForAnimationToEnd:
+    timeout: 20000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/image_url"
 - assertScreenshot:

--- a/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
+++ b/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
@@ -42,7 +42,15 @@ appId: "${APP_ID}"
     timeout: 5000
 - tapOn:
     text: "OK"
+# Wait for dialog to dismiss before navigating back
+- extendedWaitUntil:
+    visible: "Go back"
+    timeout: 3000
 - tapOn: "Go back"
+# Wait for widgets menu to appear before tapping intro screen again
+- extendedWaitUntil:
+    visible: "Widgets menu"
+    timeout: 5000
 - tapOn:
     text: "Intro screen"
 # Re-entry remounts the widget, which must reposition to the attribute's slide — same

--- a/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
+++ b/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
@@ -42,15 +42,7 @@ appId: "${APP_ID}"
     timeout: 5000
 - tapOn:
     text: "OK"
-# Wait for dialog to dismiss before navigating back
-- extendedWaitUntil:
-    visible: "Go back"
-    timeout: 3000
 - tapOn: "Go back"
-# Wait for widgets menu to appear before tapping intro screen again
-- extendedWaitUntil:
-    visible: "Widgets menu"
-    timeout: 5000
 - tapOn:
     text: "Intro screen"
 # Re-entry remounts the widget, which must reposition to the attribute's slide — same

--- a/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
+++ b/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "I"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Intro screen"
+    timeout: 10000
 - tapOn:
     text: "Intro screen"
 # Opening the page mounts the widget and waits on the runtime, unlike the in-flow waits

--- a/packages/pluggableWidgets/line-chart-native/e2e/specs/maestro/LineChart.yaml
+++ b/packages/pluggableWidgets/line-chart-native/e2e/specs/maestro/LineChart.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "L"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Line chart"
+    timeout: 10000
 - tapOn:
     text: "Line chart"
 - assertVisible:

--- a/packages/pluggableWidgets/line-chart-native/e2e/specs/maestro/LineChart.yaml
+++ b/packages/pluggableWidgets/line-chart-native/e2e/specs/maestro/LineChart.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Line chart"
 - assertVisible:
     id: "container1"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/line_chart"
 - assertScreenshot:

--- a/packages/pluggableWidgets/listview-swipe-native/e2e/specs/maestro/ListViewSwipe.yaml
+++ b/packages/pluggableWidgets/listview-swipe-native/e2e/specs/maestro/ListViewSwipe.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "L"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "List view swipe"
+    timeout: 10000
 - tapOn:
     text: "List view swipe"
 - assertVisible:

--- a/packages/pluggableWidgets/maps-native/e2e/specs/maestro/Maps_dynamic.yaml
+++ b/packages/pluggableWidgets/maps-native/e2e/specs/maestro/Maps_dynamic.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "M"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Maps"
+    timeout: 10000
 - tapOn:
     text: "Maps"
 - tapOn:

--- a/packages/pluggableWidgets/maps-native/e2e/specs/maestro/Maps_static.yaml
+++ b/packages/pluggableWidgets/maps-native/e2e/specs/maestro/Maps_static.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "M"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Maps"
+    timeout: 10000
 - tapOn:
     text: "Maps"
 - tapOn:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_custom.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_custom.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Pie doughnut chart"
+    timeout: 10000
 - tapOn:
     text: "Pie doughnut chart"
 - tapOn:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_custom.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_custom.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Doughnut chart Custom style"
 - assertVisible:
     id: "container1"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/doughnut_chart_custom"
 - assertScreenshot:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_multiple_data_points.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_multiple_data_points.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Pie doughnut chart"
+    timeout: 10000
 - tapOn:
     text: "Pie doughnut chart"
 - tapOn:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_multiple_data_points.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Doughnut_chart_multiple_data_points.yaml
@@ -15,11 +15,11 @@ appId: "${APP_ID}"
     text: "Doughnut chart Multiple data points"
 - assertVisible:
     id: "container1"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/doughnut_chart_multiple_data_points"
 - assertScreenshot:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_custom.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_custom.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Pie doughnut chart"
+    timeout: 10000
 - tapOn:
     text: "Pie doughnut chart"
 - tapOn:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_custom.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_custom.yaml
@@ -17,11 +17,11 @@ appId: "${APP_ID}"
     id: "container1"
 - assertVisible:
     id: "innerView"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/pie_chart_custom"
 - assertScreenshot:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_multiple_data_points.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_multiple_data_points.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Pie doughnut chart"
+    timeout: 10000
 - tapOn:
     text: "Pie doughnut chart"
 - tapOn:

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_multiple_data_points.yaml
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/e2e/specs/maestro/Pie_chart_multiple_data_points.yaml
@@ -17,11 +17,11 @@ appId: "${APP_ID}"
     id: "container1"
 - assertVisible:
     id: "innerView"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/pie_chart_multiple_data_points"
 - assertScreenshot:

--- a/packages/pluggableWidgets/popup-menu-native/e2e/specs/maestro/PopupMenu.yaml
+++ b/packages/pluggableWidgets/popup-menu-native/e2e/specs/maestro/PopupMenu.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Popup menu"
+    timeout: 10000
 - tapOn:
     text: "Popup menu"
 - tapOn:

--- a/packages/pluggableWidgets/progress-bar-native/e2e/specs/maestro/ProgressBar.yaml
+++ b/packages/pluggableWidgets/progress-bar-native/e2e/specs/maestro/ProgressBar.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Progress bar"
+    timeout: 10000
 - tapOn:
     text: "Progress bar"
 - assertVisible:

--- a/packages/pluggableWidgets/progress-circle-native/e2e/specs/maestro/ProgressCircle.yaml
+++ b/packages/pluggableWidgets/progress-circle-native/e2e/specs/maestro/ProgressCircle.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "P"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Progress circle"
+    timeout: 10000
 - tapOn:
     text: "Progress circle"
 - assertVisible:

--- a/packages/pluggableWidgets/qr-code-native/e2e/specs/maestro/QRCode.yaml
+++ b/packages/pluggableWidgets/qr-code-native/e2e/specs/maestro/QRCode.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "Q"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "QR code"
+    timeout: 10000
 - tapOn:
     text: "QR code"
 - assertVisible:

--- a/packages/pluggableWidgets/radio-buttons-native/e2e/specs/maestro/RadioButtons.yaml
+++ b/packages/pluggableWidgets/radio-buttons-native/e2e/specs/maestro/RadioButtons.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "R"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Radio buttons"
+    timeout: 10000
 - tapOn:
     text: "Radio buttons"
 - assertVisible:

--- a/packages/pluggableWidgets/range-slider-native/e2e/specs/maestro/RangeSlider.yaml
+++ b/packages/pluggableWidgets/range-slider-native/e2e/specs/maestro/RangeSlider.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "R"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Range slider"
+    timeout: 10000
 - tapOn:
     text: "Range slider"
 - assertVisible:

--- a/packages/pluggableWidgets/rating-native/e2e/specs/maestro/Rating.yaml
+++ b/packages/pluggableWidgets/rating-native/e2e/specs/maestro/Rating.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "R"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Rating"
+    timeout: 10000
 - tapOn:
     text: "Rating"
 - assertVisible:

--- a/packages/pluggableWidgets/repeater-native/e2e/specs/maestro/Repeater.yaml
+++ b/packages/pluggableWidgets/repeater-native/e2e/specs/maestro/Repeater.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "R"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Repeater"
+    timeout: 10000
 - tapOn:
     text: "Repeater"
 - assertVisible:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewBottomBar.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewBottomBar.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewContainer.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewContainer.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewImage.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewImage.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewListView.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewListView.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewMaps.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewMaps.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewText.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewText.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewTopBar.yaml
+++ b/packages/pluggableWidgets/safe-area-view-native/e2e/specs/maestro/SafeAreaViewTopBar.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Safe area view"
+    timeout: 10000
 - tapOn:
     text: "Safe area view"
 - tapOn:

--- a/packages/pluggableWidgets/signature-native/e2e/specs/maestro/Signature.yaml
+++ b/packages/pluggableWidgets/signature-native/e2e/specs/maestro/Signature.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Signature"
+    timeout: 10000
 - tapOn:
     text: "Signature"
 - swipe:  

--- a/packages/pluggableWidgets/slider-native/e2e/specs/maestro/Slider.yaml
+++ b/packages/pluggableWidgets/slider-native/e2e/specs/maestro/Slider.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Slider"
+    timeout: 10000
 - tapOn:
     text: "Slider"
 - assertVisible: "Dynamic ranges"

--- a/packages/pluggableWidgets/switch-native/e2e/specs/maestro/Switch.yaml
+++ b/packages/pluggableWidgets/switch-native/e2e/specs/maestro/Switch.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "S"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Switch"
+    timeout: 10000
 - tapOn:
     text: "Switch"
 - assertNotVisible: 

--- a/packages/pluggableWidgets/toggle-buttons-native/e2e/specs/maestro/ToggleButtons.yaml
+++ b/packages/pluggableWidgets/toggle-buttons-native/e2e/specs/maestro/ToggleButtons.yaml
@@ -13,11 +13,11 @@ appId: "${APP_ID}"
     text: "Toggle buttons"
 - assertVisible: 
     text: "Default:"
-# Because the image loading can take some time due to resources on emulator, we need to wait for the image to be visible
-- extendedWaitUntil: 
-     visible: randText  # Any random text that does not exist in the UI
-     optional: true  # This should be true so that the test won't fail
-     timeout: 15000 # 15 seconds
+# Wait for the screen to stop changing (image decode / sheet animation)
+# rather than sleeping a fixed time: this returns as soon as the UI
+# settles, and still caps at 15s.
+- waitForAnimationToEnd:
+    timeout: 15000
 - takeScreenshot:
     path: "maestro/images/actual/${PLATFORM}/toggle_buttons"
 - assertScreenshot:

--- a/packages/pluggableWidgets/toggle-buttons-native/e2e/specs/maestro/ToggleButtons.yaml
+++ b/packages/pluggableWidgets/toggle-buttons-native/e2e/specs/maestro/ToggleButtons.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "T"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Toggle buttons"
+    timeout: 10000
 - tapOn: 
     text: "Toggle buttons"
 - assertVisible: 

--- a/packages/pluggableWidgets/video-player-native/e2e/specs/maestro/VideoPlayer.yaml
+++ b/packages/pluggableWidgets/video-player-native/e2e/specs/maestro/VideoPlayer.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "V"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Video player"
+    timeout: 10000
 - tapOn: 
     text: "Video player"
 - assertVisible: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Custom.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Custom.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Events_android.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Events_android.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Events_ios.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_Events_ios.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_External.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_External.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_HTML.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_HTML.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_NoContent.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_NoContent.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_URL.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_URL.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 

--- a/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_UserAgent.yaml
+++ b/packages/pluggableWidgets/web-view-native/e2e/specs/maestro/WebView_UserAgent.yaml
@@ -4,6 +4,11 @@ appId: "${APP_ID}"
     file: "../../../../../../maestro/Precondition.yaml"
 - tapOn:
     text: "W"
+# Tapping the alphabet index re-renders the widget list; wait for the
+# entry before tapping it, otherwise the tap races that render.
+- extendedWaitUntil:
+    visible: "Web view"
+    timeout: 10000
 - tapOn: 
     text: "Web view"
 - tapOn: 


### PR DESCRIPTION
## Summary

  Three independent reliability fixes for the Maestro e2e suite, each a separate commit. All were found while triaging flaky iOS/Android shards: every failure below **passed on retry with the same build**, so none were product
  regressions — they were races and blind sleeps in the test harness.

  | commit | Fix |
  |---|---|
  | `b9992e70b` | Wait for the widget list to settle after tapping the alphabet index |
  | `5f102e025` | Make `restart_simulator` actually restart the iOS simulator |
  | `e7c6ab8f5` | Replace blind sleeps before screenshots with `waitForAnimationToEnd` |

  ## 1. Missing wait after the alphabet-index tap

  Flows navigate the Widgets menu by tapping a single letter — which filters and re-renders the list — then immediately tap the widget name. Nothing waited for that render, so the second tap raced it. Maestro's implicit element lookup
  usually absorbed the gap; on a loaded CI runner it didn't:

  ```
  Tap on "B"... COMPLETED
  Tap on "Bottom Sheet"... FAILED
  Element not found: Text matching regex: Bottom Sheet
  ```

  Three `bottom-sheet` flows hit this in a single run. **71 flows across 20 widgets carried the same race** — `bottom-sheet` just lost the coin flip.

  Fix: an `extendedWaitUntil` on the widget name between the two taps, matching the pattern `Modal_basic_non_native.yaml` already used for its `Open` button.

  ## 2. `restart_simulator` never restarted anything

  This is the recovery path for a wedged Maestro/XCTest driver (`iOS driver not ready in time`), but it ran `simctl shutdown all || true` — discarding the result while the XCTest runner still held the device. `prepare_ios.sh` then
  reported:

  ```
  Monitoring boot status for iPhone 17 Pro (...).
  Device already booted, nothing to do.
  ```

  So the shard got an app reinstall on top of the same wedged runtime and ran degraded from that point on — which is how a later assertion ended up timing out in an otherwise healthy run.

  Fix:
  - Kill the XCTest runner **before** shutdown — while it holds the device, shutdown can fail.
  - Target `SIMULATOR_DEVICE_ID` when known, falling back to `all`.
  - Poll until the device reports `Shutdown` (30s cap) and emit a `::warning::` if it never does, instead of silently continuing.
  - Drop the blind `sleep 10`: targeted `simctl shutdown <udid>` is synchronous (measured ~3s to reach `Shutdown`), so it only padded every retry.

  Verified against a real simulator: booted device reaches `Shutdown` in **~3.4s (was ~13s)**; an already-shutdown device logs the benign CoreSimulator 405 and continues; the unset-UDID path falls back to `all`. Both return exit 0.

  ## 3. Blind sleeps before screenshots

  20 flows waited before `takeScreenshot` by watching for text that by design never appears, with `optional: true`:

  ```yaml
  - extendedWaitUntil:
       visible: randText  # Any random text that does not exist in the UI
       optional: true
       timeout: 15000
  ```

  That's a sleep, not a wait. It **always burns the full timeout** (it can never succeed early) and never confirms the UI settled — so it's both slow and unreliable. Cost: **325s (5.4 min) per full run, per platform.** And it still
  wasn't enough — a `bottom-sheet` screenshot came in at **14.7% similarity against a 95% threshold** because the sheet was mid-expand when captured, then passed on retry.

  Replaced with `waitForAnimationToEnd`, which polls until the screen stops changing — returning as soon as the image decode / sheet animation finishes, still capping at the timeout. Already used by `animation-native`, so no new
  concept.

  **Each site keeps its existing timeout as the cap**, so no flow gets a smaller budget than before; the saving comes from returning early, not from lowering ceilings.