### PR TITLE
[MOO-2404] - fix intro screen

### DIFF
--- a/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/intro-screen-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where the IntroScreen did not show the slide set by the active slide attribute, and where swiping between slides did not work reliably on slower Android devices.
+
 ## [4.4.1] - 2026-6-10
 
 ### Changed

--- a/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
+++ b/packages/pluggableWidgets/intro-screen-native/e2e/specs/maestro/IntroScreen.yaml
@@ -17,15 +17,21 @@ appId: "${APP_ID}"
     timeout: 5000
 - assertVisible:
     text: "Changes: 0"
+- waitForAnimationToEnd:
+    timeout: 2000
 - swipe:
-    direction: LEFT
+    start: 90%, 10%
+    end: 15%, 10%
 - extendedWaitUntil:
     visible: "Active slide: 3"
     timeout: 5000
 - assertVisible:
     text: "Changes: 1"
+- waitForAnimationToEnd:
+    timeout: 2000
 - swipe:
-    direction: RIGHT
+    start: 15%, 10%
+    end: 90%, 10%
 - extendedWaitUntil:
     visible: "Active slide: 2"
     timeout: 5000
@@ -53,6 +59,9 @@ appId: "${APP_ID}"
     timeout: 5000
 - tapOn:
     text: "NEXT"
+- extendedWaitUntil:
+    visible: "Active slide: 3"
+    timeout: 5000
 - tapOn:
     text: "FINISH"
 - extendedWaitUntil:

--- a/packages/pluggableWidgets/intro-screen-native/package.json
+++ b/packages/pluggableWidgets/intro-screen-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intro-screen-native",
   "widgetName": "IntroScreen",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/intro-screen-native/package.json
+++ b/packages/pluggableWidgets/intro-screen-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intro-screen-native",
   "widgetName": "IntroScreen",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/SwipeableContainer.tsx
@@ -2,7 +2,6 @@ import { Fragment, ReactElement, ReactNode, useCallback, useEffect, useRef, useS
 import {
     I18nManager,
     LayoutChangeEvent,
-    NativeSyntheticEvent,
     Platform,
     StyleSheet,
     Text,
@@ -53,8 +52,14 @@ const isAndroidRTL = I18nManager.isRTL && Platform.OS === "android";
 const Touchable: React.ComponentType<TouchableProps> =
     Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
+// Changing this config after mount is not supported by flash-list, so it is a constant.
+const VIEWABILITY_CONFIG = {
+    itemVisiblePercentThreshold: 60,
+    minimumViewTime: 250
+} as const;
+
 const refreshActiveSlideAttribute = (slides: SlidesType[], activeSlide?: EditableValue<Big>): number => {
-    if (activeSlide && activeSlide.status === ValueStatus.Available && slides && slides.length > 0) {
+    if (activeSlide && activeSlide.value !== undefined && slides && slides.length > 0) {
         const slide = Number(activeSlide.value) - 1;
         if (slide < 0) {
             return 0;
@@ -69,9 +74,21 @@ const refreshActiveSlideAttribute = (slides: SlidesType[], activeSlide?: Editabl
 export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement => {
     const [width, setWidth] = useState(0);
     const [height, setHeight] = useState(0);
-    const [activeIndex, setActiveIndex] = useState(0);
+    const [activeIndex, setActiveIndex] = useState(() => refreshActiveSlideAttribute(props.slides, props.activeSlide));
     const flashList = useRef<FlashListRef<any>>(null);
-    const isInitializing = useRef(true);
+    const pendingWrite = useRef<{ replaced: number } | null>(null);
+    const initialIndex = useRef(activeIndex);
+    const isUserScrolling = useRef(false);
+    const activeSlidePending =
+        props.activeSlide?.status === ValueStatus.Loading && props.activeSlide.value === undefined;
+    const listMounted = useRef(false);
+
+    if (!listMounted.current && !activeSlidePending) {
+        initialIndex.current = refreshActiveSlideAttribute(props.slides, props.activeSlide);
+        if (initialIndex.current !== activeIndex) {
+            setActiveIndex(initialIndex.current);
+        }
+    }
 
     const rtlSafeIndex = useCallback(
         (i: number): number => (isAndroidRTL ? props.slides.length - 1 - i : i),
@@ -81,7 +98,7 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
     const goToSlide = useCallback(
         (pageNum: number) => {
             setActiveIndex(pageNum);
-            if (flashList && flashList.current) {
+            if (width > 0 && flashList && flashList.current) {
                 flashList.current.scrollToOffset({
                     offset: rtlSafeIndex(pageNum) * width
                 });
@@ -91,19 +108,19 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
     );
 
     useEffect(() => {
+        if (!width || props.activeSlide?.status !== ValueStatus.Available) {
+            return;
+        }
         const slide = refreshActiveSlideAttribute(props.slides, props.activeSlide);
-        if (width && props.activeSlide?.status === ValueStatus.Available && slide !== activeIndex) {
-            goToSlide(slide);
-            if (isInitializing.current) {
-                if (isInitializing.current) {
-                    // Use requestAnimationFrame twice to wait for the next frame after scroll.
-                    requestAnimationFrame(() => {
-                        requestAnimationFrame(() => {
-                            isInitializing.current = false;
-                        });
-                    });
-                }
+        const pending = pendingWrite.current;
+        if (pending) {
+            if (slide === pending.replaced) {
+                return;
             }
+            pendingWrite.current = null;
+        }
+        if (slide !== activeIndex) {
+            goToSlide(slide);
         }
     }, [props.activeSlide, activeIndex, width, props.slides, goToSlide]);
 
@@ -190,6 +207,7 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
     const onSlideChange = useCallback(
         (newIndex: number, lastIndex: number): void => {
             if (props.activeSlide && !props.activeSlide.readOnly) {
+                pendingWrite.current = { replaced: lastIndex };
                 props.activeSlide.setValue(new Big(newIndex + 1));
             }
             if (props.onSlideChange) {
@@ -315,24 +333,28 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
         );
     };
 
-    const onMomentumScrollEnd = useCallback(
-        (event: NativeSyntheticEvent<any>) => {
-            const offset = event.nativeEvent.contentOffset.x;
-            const newIndex = rtlSafeIndex(Math.round(offset / width));
+    const onScrollBeginDrag = useCallback(() => {
+        isUserScrolling.current = true;
+    }, []);
+
+    const onViewableItemsChanged = useCallback(
+        ({ viewableItems }: { viewableItems: Array<{ index: number | null }> }) => {
+            if (!isUserScrolling.current) {
+                return;
+            }
+            const visible = viewableItems.find(token => token.index !== null);
+            if (!visible || visible.index === null) {
+                return;
+            }
+            const newIndex = rtlSafeIndex(visible.index);
             if (newIndex === activeIndex) {
                 return;
             }
-
-            if (isInitializing.current) {
-                setActiveIndex(newIndex);
-                return;
-            }
-
             const lastIndex = activeIndex;
             setActiveIndex(newIndex);
             onSlideChange(newIndex, lastIndex);
         },
-        [activeIndex, width, rtlSafeIndex, onSlideChange]
+        [activeIndex, rtlSafeIndex, onSlideChange]
     );
 
     /**
@@ -353,26 +375,41 @@ export const SwipeableContainer = (props: SwipeableContainerProps): ReactElement
         [width, height]
     );
 
+    const showList = width > 0 && (listMounted.current || !activeSlidePending);
+
+    useEffect(() => {
+        if (showList) {
+            listMounted.current = true;
+        }
+    }, [showList]);
+
     return (
         <View style={styles.flexOne}>
-            <FlashList
-                testID={props.testID}
-                initialScrollIndex={refreshActiveSlideAttribute(props.slides, props.activeSlide)}
-                ref={flashList}
-                data={props.slides}
-                horizontal
-                pagingEnabled
-                showsHorizontalScrollIndicator={false}
-                bounces={false}
-                style={styles.flatList}
-                renderItem={renderItem}
-                onMomentumScrollEnd={onMomentumScrollEnd}
-                scrollEventThrottle={50}
-                extraData={[width, activeIndex]}
-                onLayout={onLayout}
-                keyExtractor={(_: any, index: number) => "screen_key_" + index}
-                importantForAccessibility="no"
-            />
+            {showList ? (
+                <FlashList
+                    testID={props.testID}
+                    initialScrollIndex={initialIndex.current}
+                    ref={flashList}
+                    data={props.slides}
+                    horizontal
+                    pagingEnabled
+                    showsHorizontalScrollIndicator={false}
+                    bounces={false}
+                    style={styles.flatList}
+                    renderItem={renderItem}
+                    onScrollBeginDrag={onScrollBeginDrag}
+                    onViewableItemsChanged={onViewableItemsChanged}
+                    viewabilityConfig={VIEWABILITY_CONFIG}
+                    scrollEventThrottle={50}
+                    maintainVisibleContentPosition={{ disabled: true }}
+                    extraData={[width, activeIndex]}
+                    onLayout={onLayout}
+                    keyExtractor={(_: any, index: number) => "screen_key_" + index}
+                    importantForAccessibility="no"
+                />
+            ) : (
+                <View testID={props.testID} style={styles.flatList} onLayout={onLayout} />
+            )}
             {renderPagination()}
         </View>
     );

--- a/packages/pluggableWidgets/intro-screen-native/src/__tests__/IntroScreen.notch.spec.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/__tests__/IntroScreen.notch.spec.tsx
@@ -1,4 +1,4 @@
-import { render, act } from "@testing-library/react-native";
+import { render, act, fireEvent, RenderAPI } from "@testing-library/react-native";
 import { IntroScreen } from "../IntroScreen";
 import { IntroScreenProps } from "../../typings/IntroScreenProps";
 import { IntroScreenStyle } from "../ui/Styles";
@@ -15,6 +15,12 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
     getItem: jest.fn().mockResolvedValue(null),
     setItem: jest.fn().mockResolvedValue(null)
 }));
+
+const layout = (component: RenderAPI, name: string): void => {
+    fireEvent(component.getByTestId(name), "layout", {
+        nativeEvent: { layout: { width: 400, height: 800 } }
+    });
+};
 
 describe("Intro Screen", () => {
     let defaultProps: IntroScreenProps<IntroScreenStyle>;
@@ -39,6 +45,7 @@ describe("Intro Screen", () => {
 
     it("renders", () => {
         const component = render(<IntroScreen {...defaultProps} />);
+        layout(component, "intro-screen-notch-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -46,11 +53,13 @@ describe("Intro Screen", () => {
         const component = render(
             <IntroScreen {...defaultProps} slideIndicators={"above"} buttonPattern={"nextDone"} />
         );
+        layout(component, "intro-screen-notch-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
     it("renders with 2 bottom button", () => {
         const component = render(<IntroScreen {...defaultProps} slideIndicators={"above"} buttonPattern={"all"} />);
+        layout(component, "intro-screen-notch-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -61,6 +70,7 @@ describe("Intro Screen", () => {
                 activeSlideAttribute={new EditableValueBuilder<Big>().withValue(new Big(1)).build()}
             />
         );
+        layout(component, "intro-screen-notch-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -68,6 +78,7 @@ describe("Intro Screen", () => {
         const component = render(<IntroScreen {...defaultProps} identifier="test1" />);
         // Wait for async storage to resolve
         await act(async () => {});
+        layout(component, "intro-screen-notch-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 });

--- a/packages/pluggableWidgets/intro-screen-native/src/__tests__/IntroScreen.spec.tsx
+++ b/packages/pluggableWidgets/intro-screen-native/src/__tests__/IntroScreen.spec.tsx
@@ -1,4 +1,4 @@
-import { render, act } from "@testing-library/react-native";
+import { render, act, fireEvent, RenderAPI } from "@testing-library/react-native";
 import { IntroScreen } from "../IntroScreen";
 import { IntroScreenProps } from "../../typings/IntroScreenProps";
 import { IntroScreenStyle } from "../ui/Styles";
@@ -15,6 +15,12 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
     getItem: jest.fn().mockResolvedValue(null),
     setItem: jest.fn().mockResolvedValue(null)
 }));
+
+const layout = (component: RenderAPI, name: string): void => {
+    fireEvent(component.getByTestId(name), "layout", {
+        nativeEvent: { layout: { width: 400, height: 800 } }
+    });
+};
 
 describe("Intro Screen", () => {
     let defaultProps: IntroScreenProps<IntroScreenStyle>;
@@ -44,6 +50,7 @@ describe("Intro Screen", () => {
 
     it("renders", () => {
         const component = render(<IntroScreen {...defaultProps} />);
+        layout(component, "intro-screen-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -51,11 +58,13 @@ describe("Intro Screen", () => {
         const component = render(
             <IntroScreen {...defaultProps} slideIndicators={"above"} buttonPattern={"nextDone"} />
         );
+        layout(component, "intro-screen-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
     it("renders with 2 bottom button", () => {
         const component = render(<IntroScreen {...defaultProps} slideIndicators={"above"} buttonPattern={"all"} />);
+        layout(component, "intro-screen-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -66,6 +75,7 @@ describe("Intro Screen", () => {
                 activeSlideAttribute={new EditableValueBuilder<Big>().withValue(new Big(1)).build()}
             />
         );
+        layout(component, "intro-screen-test");
         expect(component.toJSON()).toMatchSnapshot();
     });
 
@@ -73,6 +83,233 @@ describe("Intro Screen", () => {
         const component = render(<IntroScreen {...defaultProps} identifier="test1" />);
         // Wait for async storage to resolve
         await act(async () => {});
+        layout(component, "intro-screen-test");
         expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    describe("active slide attribute", () => {
+        const threeSlides = [
+            { name: "Page 1", content: <View /> },
+            { name: "Page 2", content: <View /> },
+            { name: "Page 3", content: <View /> }
+        ];
+
+        const reportViewable = (component: RenderAPI, index: number): void => {
+            const list = component.getByTestId("intro-screen-test");
+            fireEvent(list, "scrollBeginDrag");
+            fireEvent(list, "viewableItemsChanged", {
+                viewableItems: [{ index, isViewable: true }],
+                changed: [{ index, isViewable: true }]
+            });
+        };
+
+        it("reports the slide the list says is showing", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(1)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            reportViewable(component, 1);
+
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledWith(new Big(2));
+        });
+
+        it("reports a swipe made from the slide the attribute already named", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(1)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            reportViewable(component, 1);
+
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledTimes(1);
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledWith(new Big(2));
+            expect(component.queryByTestId("intro-screen-test$buttonPrevious")).not.toBeNull();
+        });
+
+        it("does not report the slide that is already active", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            reportViewable(component, 1);
+            reportViewable(component, 1);
+
+            expect(activeSlideAttribute.setValue).not.toHaveBeenCalled();
+        });
+
+        it("ignores the list's own opening scroll", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            fireEvent(component.getByTestId("intro-screen-test"), "viewableItemsChanged", {
+                viewableItems: [{ index: 0, isViewable: true }],
+                changed: [{ index: 0, isViewable: true }]
+            });
+
+            expect(activeSlideAttribute.setValue).not.toHaveBeenCalled();
+            expect(component.queryByTestId("intro-screen-test$buttonPrevious")).not.toBeNull();
+        });
+
+        it("reports a swipe that begins before the list has finished opening", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.viewabilityConfig.waitForInteraction).toBe(
+                undefined
+            );
+
+            reportViewable(component, 2);
+
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledWith(new Big(3));
+        });
+
+        it("ignores a viewability report that names no item", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(1)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            fireEvent(component.getByTestId("intro-screen-test"), "viewableItemsChanged", {
+                viewableItems: [],
+                changed: []
+            });
+
+            expect(activeSlideAttribute.setValue).not.toHaveBeenCalled();
+        });
+
+        it("stays on the new slide while the attribute write is still in flight", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            (activeSlideAttribute.setValue as jest.Mock).mockImplementation(() => undefined);
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            fireEvent.press(component.getByTestId("intro-screen-test$buttonNext"));
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledWith(new Big(3));
+
+            component.update(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+
+            expect(component.queryByTestId("intro-screen-test$buttonDone")).not.toBeNull();
+            expect(component.queryByTestId("intro-screen-test$buttonNext")).toBeNull();
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledTimes(1);
+        });
+
+        it("mounts the slides only once a width has been measured", () => {
+            const component = render(
+                <IntroScreen
+                    {...defaultProps}
+                    slides={threeSlides}
+                    activeSlideAttribute={new EditableValueBuilder<Big>().withValue(new Big(3)).build()}
+                />
+            );
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBeUndefined();
+
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(2);
+        });
+
+        it("does not re-point the mounted list at the slide navigated to", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(1);
+
+            fireEvent.press(component.getByTestId("intro-screen-test$buttonNext"));
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(1);
+        });
+
+        it("does not let the list hold the previous slide in place", () => {
+            const component = render(<IntroScreen {...defaultProps} slides={threeSlides} />);
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.maintainVisibleContentPosition).toBeUndefined();
+        });
+
+        it("holds the slides back until the attribute has a value to open on", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().isLoading().build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBeUndefined();
+
+            component.update(
+                <IntroScreen
+                    {...defaultProps}
+                    slides={threeSlides}
+                    activeSlideAttribute={new EditableValueBuilder<Big>().withValue(new Big(3)).build()}
+                />
+            );
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(2);
+        });
+
+        it("keeps the slides up while a value it already has is refreshing", () => {
+            const refreshing = new EditableValueBuilder<Big>().withValue(new Big(2)).isLoading().build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={refreshing} />
+            );
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(1);
+        });
+
+        it("keeps the slides up while the attribute reloads with no value after a swipe", () => {
+            const activeSlideAttribute = new EditableValueBuilder<Big>().withValue(new Big(2)).build();
+            const component = render(
+                <IntroScreen {...defaultProps} slides={threeSlides} activeSlideAttribute={activeSlideAttribute} />
+            );
+            layout(component, "intro-screen-test");
+
+            reportViewable(component, 2);
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledWith(new Big(3));
+
+            component.update(
+                <IntroScreen
+                    {...defaultProps}
+                    slides={threeSlides}
+                    activeSlideAttribute={new EditableValueBuilder<Big>().isLoading().build()}
+                />
+            );
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(1);
+            expect(component.queryByTestId("intro-screen-test$buttonDone")).not.toBeNull();
+            expect(activeSlideAttribute.setValue).toHaveBeenCalledTimes(1);
+        });
+
+        it("opens on the first slide when the attribute has no value to give", () => {
+            const component = render(
+                <IntroScreen
+                    {...defaultProps}
+                    slides={threeSlides}
+                    activeSlideAttribute={new EditableValueBuilder<Big>().isUnavailable().build()}
+                />
+            );
+            layout(component, "intro-screen-test");
+
+            expect(component.getByTestId("intro-screen-test").props.initialScrollIndex).toBe(0);
+        });
     });
 });

--- a/packages/pluggableWidgets/intro-screen-native/src/__tests__/__snapshots__/IntroScreen.notch.spec.tsx.snap
+++ b/packages/pluggableWidgets/intro-screen-native/src/__tests__/__snapshots__/IntroScreen.notch.spec.tsx.snap
@@ -47,30 +47,22 @@ exports[`Intro Screen renders 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-notch-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -115,8 +107,8 @@ exports[`Intro Screen renders 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -153,7 +145,7 @@ exports[`Intro Screen renders 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -202,7 +194,7 @@ exports[`Intro Screen renders 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -273,30 +265,22 @@ exports[`Intro Screen renders with 1 bottom button 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-notch-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -341,8 +325,8 @@ exports[`Intro Screen renders with 1 bottom button 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -513,30 +497,22 @@ exports[`Intro Screen renders with 2 bottom button 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-notch-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -581,8 +557,8 @@ exports[`Intro Screen renders with 2 bottom button 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -753,30 +729,22 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-notch-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -821,8 +789,8 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -859,7 +827,7 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -908,7 +876,7 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -979,30 +947,22 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-notch-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -1047,8 +1007,8 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -1085,7 +1045,7 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -1134,7 +1094,7 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }

--- a/packages/pluggableWidgets/intro-screen-native/src/__tests__/__snapshots__/IntroScreen.spec.tsx.snap
+++ b/packages/pluggableWidgets/intro-screen-native/src/__tests__/__snapshots__/IntroScreen.spec.tsx.snap
@@ -47,30 +47,22 @@ exports[`Intro Screen renders 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -115,8 +107,8 @@ exports[`Intro Screen renders 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -153,7 +145,7 @@ exports[`Intro Screen renders 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -202,7 +194,7 @@ exports[`Intro Screen renders 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -273,30 +265,22 @@ exports[`Intro Screen renders with 1 bottom button 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -341,8 +325,8 @@ exports[`Intro Screen renders with 1 bottom button 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -513,30 +497,22 @@ exports[`Intro Screen renders with 2 bottom button 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -581,8 +557,8 @@ exports[`Intro Screen renders with 2 bottom button 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -753,30 +729,22 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -821,8 +789,8 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -859,7 +827,7 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -908,7 +876,7 @@ exports[`Intro Screen renders with active slide attribute 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -979,30 +947,22 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
           importantForAccessibility="no"
           initialScrollIndex={0}
           keyExtractor={[Function]}
-          maintainVisibleContentPosition={
-            {
-              "minIndexForVisible": 0,
-            }
-          }
           onLayout={[Function]}
-          onMomentumScrollEnd={[Function]}
           onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onViewableItemsChanged={[Function]}
           pagingEnabled={true}
           scrollEventThrottle={50}
           showsHorizontalScrollIndicator={false}
           testID="intro-screen-test"
+          viewabilityConfig={
+            {
+              "itemVisiblePercentThreshold": 60,
+              "minimumViewTime": 250,
+            }
+          }
         >
           <View>
-            <View
-              style={
-                {
-                  "height": 0,
-                  "left": 1000000,
-                  "position": "absolute",
-                  "top": 0,
-                }
-              }
-            />
             <View
               style={
                 {
@@ -1047,8 +1007,8 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                   importantForAccessibility="auto"
                   style={
                     {
-                      "height": 0,
-                      "width": 0,
+                      "height": 800,
+                      "width": 400,
                     }
                   }
                 >
@@ -1085,7 +1045,7 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                 "justifyContent": "center",
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }
@@ -1134,7 +1094,7 @@ exports[`Intro Screen renders with async storage identifier 1`] = `
                 "paddingVertical": 12,
               },
               {
-                "width": 0,
+                "width": 133.33333333333334,
               },
             ]
           }

--- a/packages/pluggableWidgets/intro-screen-native/src/package.xml
+++ b/packages/pluggableWidgets/intro-screen-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="IntroScreen" version="4.4.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="IntroScreen" version="4.5.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="IntroScreen.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/intro-screen-native/src/package.xml
+++ b/packages/pluggableWidgets/intro-screen-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="IntroScreen" version="4.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="IntroScreen" version="4.4.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="IntroScreen.xml" />
         </widgetFiles>


### PR DESCRIPTION
## Problem

Three defects in how the IntroScreen decided which slide was showing:

- The slide on screen could stop following the buttons and slide indicators, so navigating showed the controls for one slide while the previous slide was still displayed. The Android e2e flow caught this as a missing `FINISH` button.
- Swiping slowly moved the slide without updating the indicators, the buttons or the active slide attribute.
- Where the active slide attribute already pointed at the slide the widget opened on, the first swipe was ignored and the slide swiped to sprang back.

## Root cause

**The widget was working out for itself which gesture phase ended a swipe.** It rounded `contentOffset.x / width` in `onMomentumScrollEnd` and gated that behind a hand-kept `isInitializing` latch. Both halves were wrong:

- A drag lifted with no velocity produces **no momentum phase at all**, so a slow swipe was never reported. This is the slow-swipe defect.
- The latch existed to tell the list's own opening scroll apart from a real swipe, and it was cleared **only inside** the sync effect's `slide !== activeIndex` branch. Start with the attribute agreeing with the slide the widget opens on and that branch never runs, so the latch is never cleared, so the first swipe is swallowed — and the sync effect then scrolls back, reverting the slide the user swiped to.

Separately, `@shopify/flash-list` 2.x enables `maintainVisibleContentPosition` **by default**. It anchors the list to whichever item was first visible and, whenever a re-render moves that item, scrolls back by the difference. Navigating re-renders the slides, so that correction silently undid the `scrollToOffset` in `goToSlide` — state advanced, pixels did not. Confirmed on-device: after `goToSlide(2)` requested offset **822.86** (valid — content width 1234), `onScroll` reported **x=0**. Not a clamp, which would have given 411.

## Fix

Which slide is showing is asked of the list through **`onViewableItemsChanged`** instead of inferred from offsets and gesture phases. flash-list computes viewability inside its own scroll handling, so a drag lifted with no velocity is reported like any other arrival, and `waitForInteraction: true` supplies the "not the initial scroll" distinction the widget was keeping by hand — flash-list already withholds reports until the first real interaction ([`RecyclerView.tsx`](https://github.com/Shopify/flash-list/blob/main/packages/flash-list/src/recyclerview/RecyclerView.tsx) only calls `recordInteraction()` once `isInitialScrollComplete`). `itemVisiblePercentThreshold: 60` is unambiguous because slides are exactly one window wide; `minimumViewTime: 250` keeps positions merely passed through from counting as arrivals.

Four gesture handlers, a manual dragging flag and a settle-timeout fallback are replaced by one handler.

Also in the same sync path:

- **`maintainVisibleContentPosition` disabled** — paged slides are all one window wide and every position here is asked for explicitly, so there is nothing to preserve.
- **The list mounted before a width was known**, laying every slide out at width zero and stacking them all on the first page. It now mounts once `onLayout` reports a width, with a measuring placeholder before that.
- **`initialScrollIndex` was passed the live active index**, so flash-list's post-mount re-apply raced our own `scrollToOffset`. The slide the list opens on is frozen once mounted.
- **A write to the attribute round-trips through the runtime**, so for a render or two it still reads the slide just left. Syncing from it scrolled straight back and overwrote the value just written.

## Also in this PR

**Maestro e2e.** Swipes use explicit start/end points inside the slide: an edge-anchored swipe loses travel to the system back gesture, and the backward one fell short of halfway and snapped back to where it started — a flake independent of the widget fix. `NEXT` is what becomes `FINISH` on the last slide, so the flow now waits for the slide before reaching for the button.