### PR TITLE
chore: remove local image build and use GHCR retrieve

### DIFF
--- a/.github/workflows/BuildMpk.yml
+++ b/.github/workflows/BuildMpk.yml
@@ -24,6 +24,9 @@ jobs:
   publish_release:
     name: "Build MPK"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: "Checking-out code"
@@ -49,6 +52,12 @@ jobs:
           echo "VERSION=${NEW_VER}" >> "$GITHUB_OUTPUT"
       - name: "Building native widgets and js actions"
         run: pnpm -r run release
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Updating Native Mobile Resources project"
         run: pnpm run build-mpk
         env:

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -66,17 +66,9 @@ async function getPackageInfo(path) {
     }
 }
 
-// Create reusable mxbuild image
+// Create the module MPK with the published mxbuild image
 async function createModuleMpkInDocker(sourceDir, moduleName, mendixVersion, excludeFilesRegExp) {
-    const existingImages = (await execShellCommand(`docker image ls -q mxbuild:${mendixVersion}`)).toString().trim();
-    if (!existingImages) {
-        console.log(`Creating new mxbuild docker image...`);
-        await execShellCommand(
-            `docker build -f ${join(process.cwd(), "scripts/automation/mxbuild.Dockerfile")} ` +
-                `--build-arg MENDIX_VERSION=${mendixVersion} ` +
-                `-t mxbuild:${mendixVersion} ${process.cwd()}`
-        );
-    }
+    const mxbuildImage = `ghcr.io/mendix/native-widgets/mxbuild:${mendixVersion}`;
 
     // Build testProject and regenerate JS actions
     // 1. mx update-widgets: Updates widget files
@@ -85,7 +77,7 @@ async function createModuleMpkInDocker(sourceDir, moduleName, mendixVersion, exc
     const projectFile = basename((await getFiles(sourceDir, [`.mpr`]))[0]);
     await execShellCommand(
         `docker run -t -v ${sourceDir}:/source ` +
-            `--rm mxbuild:${mendixVersion} bash -c "mx update-widgets --loose-version-check /source/${projectFile} && mxbuild --target=package /source/${projectFile} && dotnet /tmp/mxbuild/modeler/mx.dll create-module-package ${
+            `--rm ${mxbuildImage} bash -c "mx update-widgets --loose-version-check /source/${projectFile} && mxbuild --target=package /source/${projectFile} && dotnet /tmp/mxbuild/modeler/mx.dll create-module-package ${
                 excludeFilesRegExp ? `--exclude-files='${excludeFilesRegExp}'` : ""
             } /source/${projectFile} ${moduleName}"`
     );

--- a/scripts/release/module-automation/moduleVersion.ts
+++ b/scripts/release/module-automation/moduleVersion.ts
@@ -18,8 +18,9 @@ function runCommand(command: string, workingDirectory: string): Promise<CommandR
 }
 
 function dockerMxCommand(mendixVersion: string, projectFile: string, mxArguments: string): string {
+    const mxbuildImage = `ghcr.io/mendix/native-widgets/mxbuild:${mendixVersion}`;
     return (
-        `docker run -t -v ${dirname(projectFile)}:/source --rm mxbuild:${mendixVersion} ` +
+        `docker run -t -v ${dirname(projectFile)}:/source --rm ${mxbuildImage} ` +
         `bash -c "mx ${mxArguments.replace("{project}", `/source/${basename(projectFile)}`)}"`
     );
 }


### PR DESCRIPTION
- Updated module versioning and MPK creation to use the published [ghcr.io/mendix/native-widgets/mxbuild:<version>](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) image.
- Added read-only GHCR permissions and authentication to the Build MPK workflow.
- Removed the redundant local mxbuild image check and build fallback.

The pipeline used the unqualified [mxbuild:<version>](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) name, causing Docker to search Docker Hub instead of GHCR. Using one canonical GHCR image ensures both build stages use the same published tooling, while Docker automatically reuses the image locally or pulls it when missing.