### PR TITLE
[MOO-2472] : Update the base branch for changelog automated pr

### DIFF
--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -158,7 +158,7 @@ async function commitAndCreatePullRequest(moduleInfo) {
         `git checkout -b ${changelogBranchName} && git add . && git commit -m "chore(${moduleInfo.nameWithDash}): update changelogs" && git push --set-upstream origin ${changelogBranchName}`
     );
     await execShellCommand(
-        `gh pr create --title "${moduleInfo.nameWithSpace}: Updating changelogs" --body "This is an automated PR." --base main --head ${changelogBranchName}`
+        `gh pr create --title "${moduleInfo.nameWithSpace}: Updating changelogs" --body "This is an automated PR." --base mx/11.6.x --head ${changelogBranchName}`
     );
     console.log("Created PR for changelog updates.");
 }


### PR DESCRIPTION
This PR fixes the base branch to mx/11.6.x for the automated changelogs pr which was created as a part of marketplace release. Currently its created against Main branch & we have to manually change it to point to mx/11.6.x