### PR TITLE
docs: fix 12 typos in READMEs and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Note: this applies to NMR for latest Studio Pro (currently 9.X)
 -   Ensure your current git branch includes all changes intended to be released.
     -   Including updates to widgets' changelogs and semver version in `package.json` and `package.xml`.
 -   Build all widgets in release mode; in root of repo run `pnpm release`.
--   Copy each widgets' `.mpk` to the NMR project's `/widgets` directory, overriding any existing `.mpk`s.
--   (conditional) If the widget is new, it needs to be listed on the NMR project page `NativeModileResources._WidgetExport`.
+-   Copy each widget's `.mpk` to the NMR project's `/widgets` directory, overriding any existing `.mpk`s.
+-   (conditional) If the widget is new, it needs to be listed on the NMR project page `NativeMobileResources._WidgetExport`.
     -   Configure the widget with basic minimum requirements (e.g. datasource), enough to avoid any project errors.
 -   Ensure monorepo's `mobile-resources-native` package has correct changelog and `package.json` version.
 -   cd to `packages/jsActions/mobile-resources-native` and run `pnpm release`.

--- a/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
@@ -124,7 +124,7 @@ To enable it you can set the new SignIn action parameter `useAuthToken` to `true
     -   Base64DecodeToImage
     -   Base64Encode
     -   GetStraightLineDistance
--   New "Enum_DistanceUnit" enum is introduce for GetStraightLineDistance action
+-   New "Enum_DistanceUnit" enum is introduced for GetStraightLineDistance action
 
 ## [2.5.0] Nanoflow Commons - 2022-7-25
 
@@ -153,7 +153,7 @@ To enable it you can set the new SignIn action parameter `useAuthToken` to `true
 ### Added
 
 -   We introduced a new [Clear cached session data] action to clear the cached session data from local storage.
--   We introdcued a new [Reload] action that reloads the app.
+-   We introduced a new [Reload] action that reloads the app.
 
 ### Breaking
 

--- a/packages/pluggableWidgets/bottom-sheet-native/README.md
+++ b/packages/pluggableWidgets/bottom-sheet-native/README.md
@@ -43,12 +43,12 @@ A main object has four objects. Objects with **?** are optional and do not need 
 
 #### ModalItemsStyle
 
-| Style Key                      | Description                                                 |
-| ------------------------------ | ----------------------------------------------------------- |
-| defaultStyle?: BasicItemStyle; | Styles all basic items which has "default" style selected\. |
-| primaryStyle?: BasicItemStyle; | Styles all basic items which has "primary" style selected\. |
-| dangerStyle?: BasicItemStyle;  | Styles all basic items which has "danger" style selected\.  |
-| customStyle?: BasicItemStyle;  | Styles all basic items which has "custom" style selected\.  |
+| Style Key                      | Description                                                  |
+| ------------------------------ | ------------------------------------------------------------ |
+| defaultStyle?: BasicItemStyle; | Styles all basic items which have "default" style selected\. |
+| primaryStyle?: BasicItemStyle; | Styles all basic items which have "primary" style selected\. |
+| dangerStyle?: BasicItemStyle;  | Styles all basic items which have "danger" style selected\.  |
+| customStyle?: BasicItemStyle;  | Styles all basic items which have "custom" style selected\.  |
 
 Example:
 

--- a/packages/pluggableWidgets/carousel-native/README.md
+++ b/packages/pluggableWidgets/carousel-native/README.md
@@ -24,10 +24,10 @@ export myCarouselStyle = {
 
 #### Pagination
 
-| Style Key                                                                         | Description                                                                                                    |
-| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| container: ViewStyle                                                              | Styles the main view around pagination, regardless of text or dot.                                             |
-| dotStyle: ViewStyle + color?: string                                              | Styles all the pagination dots.                                                                                |
-| inactiveDotStyle: ViewStyle + {opacity?: number; scale?: number; color?: string}; | Additional styles for inactive dots. Will be merged with dotStyle.                                             |
-| dotContainerStyle: ViewStyle                                                      | Styles the view around individual pagination dots                                                              |
-| text: TextStyle                                                                   | Will be applied when there is more than 5 elements in carousel and pagination buttons becomes text like "1/5". |
+| Style Key                                                                         | Description                                                                                                   |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| container: ViewStyle                                                              | Styles the main view around pagination, regardless of text or dot.                                            |
+| dotStyle: ViewStyle + color?: string                                              | Styles all the pagination dots.                                                                               |
+| inactiveDotStyle: ViewStyle + {opacity?: number; scale?: number; color?: string}; | Additional styles for inactive dots. Will be merged with dotStyle.                                            |
+| dotContainerStyle: ViewStyle                                                      | Styles the view around individual pagination dots                                                             |
+| text: TextStyle                                                                   | Will be applied when there is more than 5 elements in carousel and pagination buttons become text like "1/5". |

--- a/packages/pluggableWidgets/gallery-native/README.md
+++ b/packages/pluggableWidgets/gallery-native/README.md
@@ -33,7 +33,7 @@ Defines the amount of data shown for each page or the limit to be presented.
 
 ### 2.3.2 Pagination
 
-You can choose between `Load more button` (button being presented below) or `Virtual scrolling` (mechanism that automatically loads data when the users reaches the bottom of the scrollbar).
+You can choose between `Load more button` (button being presented below) or `Virtual scrolling` (mechanism that automatically loads data when the user reaches the bottom of the scrollbar).
 
 ### 2.3.3 Empty Message
 
@@ -51,7 +51,7 @@ Triggers an action (such as a nanoflow, Show page, etc. action) when the end-use
 
 ### 2.4.2 On Pull Down Action
 
-Triggers an action (such as a nanoflow, Synchronize, etc. action) when the end-user swipe down of the list.
+Triggers an action (such as a nanoflow, Synchronize, etc. action) when the end-user swipes down on the list.
 
 ### Filtering
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -8,7 +8,7 @@
 
 -   JS actions in `nanoflow-actions-native` are included in and released with Nanoflow Commons.
 
-1. Make sure each changed widget has an appropriate change to it's `package.json` & `package.xml` (version bump) and changelog update before releasing.
+1. Make sure each changed widget has an appropriate change to its `package.json` & `package.xml` (version bump) and changelog update before releasing.
 1. In `CHANGELOG.md`, try to avoid using special characters like backtick[`] around the text while updating the changelog because it won't be able to parse the text; instead you can use square brackets[].
 1. Each widget (e.g. `bar-chart-native`) or module's (e.g. `mobile-resources-native`) `minimumMXVersion` in `package.json` should match the `NativeComponentsTestProject` Mendix project Studio Pro version. You can pull the [repo](https://github.com/mendix/Native-Mobile-Resources) into Windows and double-click the `.mpr` in the root. You should have at least one Studio Pro installation for this to work.
 1. On `master`, once all to-be-released changes are merged, add a tag to the commit you want to create a release from. The tag should


### PR DESCRIPTION
## Summary

Fixes 12 typos and grammar errors across 6 documentation files. No functional changes - documentation and changelog prose only.

### `README.md`
- `Copy each widgets' \`.mpk\`` -> `each widget's` (singular possessive; the plural possessive uses elsewhere in the file, e.g. "the widgets' changelogs", are correct and were left alone)
- `` `NativeModileResources._WidgetExport` `` -> `NativeMobileResources` (the module is spelled `NativeMobileResources` in 18 other places in this repo, including line 81 of this same file)

### `packages/jsActions/nanoflow-actions-native/CHANGELOG.md`
- `enum is introduce for` -> `is introduced for`
- `We introdcued a new [Reload] action` -> `We introduced`

### `packages/pluggableWidgets/gallery-native/README.md`
- `when the users reaches the bottom` -> `when the user reaches`
- `when the end-user swipe down of the list` -> `swipes down on the list` (matches the third-person phrasing of the neighbouring "On Click Action" entry)

### `packages/pluggableWidgets/bottom-sheet-native/README.md`
- `Styles all basic items which has "<x>" style selected` -> `which have`, in all four `ModalItemsStyle` rows (default / primary / danger / custom)

### `packages/pluggableWidgets/carousel-native/README.md`
- `pagination buttons becomes text like "1/5"` -> `buttons become`

### `scripts/release/README.md`
- `an appropriate change to it's \`package.json\`` -> `its`

### Note on whitespace
The bottom-sheet and carousel changes sit inside markdown tables, so the column padding shifted. Both files were re-run through Prettier (`--prose-wrap preserve --tab-width 4 --print-width 120`), which reproduced them byte-identically before the edit, so the extra whitespace-only lines in those two tables are exactly what the repo's own formatter produces. Happy to drop the carousel table's padding-only lines if you would rather keep the diff to a single line.