### PR TITLE
[MOO-2463] : Background image native not rendering fix 11-6-x

### DIFF
--- a/packages/pluggableWidgets/background-image-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/background-image-native/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   Fixed background image widget not visible.
+
 ## [2.2.0] - 2024-12-3
 
 ### Changed

--- a/packages/pluggableWidgets/background-image-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/background-image-native/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
--   Fixed background image widget not visible.
+-   Fixed background image widget not visible when there is no content inside it.
 
 ## [2.2.0] - 2024-12-3
 

--- a/packages/pluggableWidgets/background-image-native/package.json
+++ b/packages/pluggableWidgets/background-image-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "background-image-native",
   "widgetName": "BackgroundImage",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/background-image-native/src/BackgroundImage.tsx
+++ b/packages/pluggableWidgets/background-image-native/src/BackgroundImage.tsx
@@ -33,8 +33,14 @@ export function BackgroundImage(props: BackgroundImageProps<BackgroundImageStyle
         { opacity, resizeMode }
     ] as StyleProp<SvgImageStyle>;
 
+    // When there's no content, allow container to grow to fill available space
+    // When there's content, size container to content
+    const containerStyle = props.content
+        ? styles.container
+        : [styles.container, { flexGrow: 1, flexShrink: 1, flexBasis: "auto" as const }];
+
     return (
-        <View style={styles.container} testID={name}>
+        <View style={containerStyle} testID={name}>
             <Image source={image.value} style={imageStyle} color={styles.image.svgColor} testID={`${name}$image`} />
             {props.content}
         </View>

--- a/packages/pluggableWidgets/background-image-native/src/BackgroundImage.tsx
+++ b/packages/pluggableWidgets/background-image-native/src/BackgroundImage.tsx
@@ -4,7 +4,7 @@ import { ValueStatus } from "mendix";
 import { Image, SvgImageStyle } from "mendix/components/native/Image";
 import { flattenStyles } from "@mendix/piw-native-utils-internal";
 
-import { BackgroundImageStyle, defaultBackgroundImageStyle } from "./ui/Styles";
+import { BackgroundImageStyle, defaultBackgroundImageStyle, NO_CONTENT_CONTAINER_STYLE } from "./ui/Styles";
 import { BackgroundImageProps } from "../typings/BackgroundImageProps";
 
 export function BackgroundImage(props: BackgroundImageProps<BackgroundImageStyle>): JSX.Element | null {
@@ -35,9 +35,7 @@ export function BackgroundImage(props: BackgroundImageProps<BackgroundImageStyle
 
     // When there's no content, allow container to grow to fill available space
     // When there's content, size container to content
-    const containerStyle = props.content
-        ? styles.container
-        : [styles.container, { flexGrow: 1, flexShrink: 1, flexBasis: "auto" as const }];
+    const containerStyle = props.content ? styles.container : [NO_CONTENT_CONTAINER_STYLE, styles.container];
 
     return (
         <View style={containerStyle} testID={name}>

--- a/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
+++ b/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
@@ -2,7 +2,13 @@
 
 exports[`BackgroundImage renders content only when image is unavailable 1`] = `
 <View
-  style={{}}
+  style={
+    {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
   testID="backgroundImageTest"
 >
   <Image
@@ -44,6 +50,9 @@ exports[`BackgroundImage renders with custom styles 1`] = `
 <View
   style={
     {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "height": "80%",
     }
   }
@@ -85,7 +94,13 @@ exports[`BackgroundImage renders with custom styles 1`] = `
 
 exports[`BackgroundImage renders with default styles 1`] = `
 <View
-  style={{}}
+  style={
+    {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
   testID="backgroundImageTest"
 >
   <Image
@@ -121,7 +136,13 @@ exports[`BackgroundImage renders with default styles 1`] = `
 
 exports[`BackgroundImage renders without content 1`] = `
 <View
-  style={{}}
+  style={
+    {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
   testID="backgroundImageTest"
 >
   <Image
@@ -154,7 +175,13 @@ exports[`BackgroundImage renders without content 1`] = `
 
 exports[`BackgroundImage use correct opacity when image opacity is out of range 1`] = `
 <View
-  style={{}}
+  style={
+    {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
   testID="backgroundImageTest"
 >
   <Image
@@ -190,7 +217,13 @@ exports[`BackgroundImage use correct opacity when image opacity is out of range 
 
 exports[`BackgroundImage use correct opacity when image opacity is out of range 2`] = `
 <View
-  style={{}}
+  style={
+    {
+      "flexBasis": "auto",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
   testID="backgroundImageTest"
 >
   <Image

--- a/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
+++ b/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
@@ -123,12 +123,12 @@ exports[`BackgroundImage renders without content 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexBasis": "auto",
         "flexGrow": 1,
         "flexShrink": 1,
       },
+      {},
     ]
   }
   testID="backgroundImageTest"

--- a/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
+++ b/packages/pluggableWidgets/background-image-native/src/__tests__/__snapshots__/BackgroundImage.spec.tsx.snap
@@ -2,13 +2,7 @@
 
 exports[`BackgroundImage renders content only when image is unavailable 1`] = `
 <View
-  style={
-    {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
+  style={{}}
   testID="backgroundImageTest"
 >
   <Image
@@ -50,9 +44,6 @@ exports[`BackgroundImage renders with custom styles 1`] = `
 <View
   style={
     {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
       "height": "80%",
     }
   }
@@ -94,13 +85,7 @@ exports[`BackgroundImage renders with custom styles 1`] = `
 
 exports[`BackgroundImage renders with default styles 1`] = `
 <View
-  style={
-    {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
+  style={{}}
   testID="backgroundImageTest"
 >
   <Image
@@ -137,11 +122,14 @@ exports[`BackgroundImage renders with default styles 1`] = `
 exports[`BackgroundImage renders without content 1`] = `
 <View
   style={
-    {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
+    [
+      {},
+      {
+        "flexBasis": "auto",
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
   }
   testID="backgroundImageTest"
 >
@@ -175,13 +163,7 @@ exports[`BackgroundImage renders without content 1`] = `
 
 exports[`BackgroundImage use correct opacity when image opacity is out of range 1`] = `
 <View
-  style={
-    {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
+  style={{}}
   testID="backgroundImageTest"
 >
   <Image
@@ -217,13 +199,7 @@ exports[`BackgroundImage use correct opacity when image opacity is out of range 
 
 exports[`BackgroundImage use correct opacity when image opacity is out of range 2`] = `
 <View
-  style={
-    {
-      "flexBasis": "auto",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
+  style={{}}
   testID="backgroundImageTest"
 >
   <Image

--- a/packages/pluggableWidgets/background-image-native/src/package.xml
+++ b/packages/pluggableWidgets/background-image-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="BackgroundImage" version="2.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="BackgroundImage" version="2.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BackgroundImage.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
@@ -11,6 +11,10 @@ export interface BackgroundImageStyle extends Style {
 }
 
 export const defaultBackgroundImageStyle: BackgroundImageStyle = {
-    container: {},
+    container: {
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: "auto"
+    },
     image: {}
 };

--- a/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
@@ -14,3 +14,5 @@ export const defaultBackgroundImageStyle: BackgroundImageStyle = {
     container: {},
     image: {}
 };
+
+export const NO_CONTENT_CONTAINER_STYLE = { flexGrow: 1, flexShrink: 1, flexBasis: "auto" as const };

--- a/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/background-image-native/src/ui/Styles.ts
@@ -11,10 +11,6 @@ export interface BackgroundImageStyle extends Style {
 }
 
 export const defaultBackgroundImageStyle: BackgroundImageStyle = {
-    container: {
-        flexGrow: 1,
-        flexShrink: 1,
-        flexBasis: "auto"
-    },
+    container: {},
     image: {}
 };


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ✅ 
-   Compatible with: MX 11
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 
-   Works in Android ✅ 
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

#### Feature specific

-   Comply with designs ✅ 
-   Comply with PM's requirements ✅ 


## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR fixes the background image native widget not rendering issue whenever there is no content in the background image native widget. Now with this change , if the content is there in image , it will work as before & if no content only i.e. background image , it will fill up to take the available space.